### PR TITLE
fix: private Eric conversation per user

### DIFF
--- a/apps/api/src/scripts/provision-staging-users.ts
+++ b/apps/api/src/scripts/provision-staging-users.ts
@@ -10,7 +10,7 @@ config({ path: resolve(__dirname, "../../../../.env") });
 const { db } = await import("../db/index.js");
 const { auth } = await import("../auth/index.js");
 const { users } = await import("../db/schema/index.js");
-const { addUserToEricConversation, ensureDefaultEricWorkspace } = await import("../services/eric-conversation.js");
+const { ensureEricConversationForUser, ensureDefaultEricWorkspace } = await import("../services/eric-conversation.js");
 
 /** Default Buenaça team (Gmail plus-addressing → same inbox as buenacagaucha@gmail.com). */
 const DEFAULT_TEAM: { email: string; name: string; role: "owner" | "admin" | "user" }[] = [
@@ -55,7 +55,7 @@ async function provisionStagingUsers() {
         await db.update(users).set({ role: u.role }).where(eq(users.id, existing.id));
         console.log(`Updated role for ${u.email} -> ${u.role}`);
       }
-      await addUserToEricConversation(db, existing.id);
+      await ensureEricConversationForUser(db, existing.id);
       console.log(`Eric membership ensured for existing ${u.email}`);
       continue;
     }
@@ -70,15 +70,15 @@ async function provisionStagingUsers() {
     }
 
     await db.update(users).set({ role: u.role }).where(eq(users.id, res.user.id));
-    await addUserToEricConversation(db, res.user.id);
+    await ensureEricConversationForUser(db, res.user.id);
     console.log(`Created ${u.email} (${u.name}) role=${u.role}`);
   }
 
   const everyone = await db.select({ id: users.id }).from(users);
   for (const row of everyone) {
-    await addUserToEricConversation(db, row.id);
+    await ensureEricConversationForUser(db, row.id);
   }
-  console.log(`Eric conversation membership backfilled for ${everyone.length} user(s).`);
+  console.log(`Eric conversation ensured for ${everyone.length} user(s).`);
   console.log("Done.");
   process.exit(0);
 }

--- a/apps/api/src/services/eric-conversation.ts
+++ b/apps/api/src/services/eric-conversation.ts
@@ -3,7 +3,29 @@ import type { Database } from "../db/index.js";
 import { agents, conversationMembers, conversations, users } from "../db/schema/index.js";
 
 /**
- * Creates the default Eric agent + AI conversation and adds every existing user as a member
+ * Creates a private Eric AI conversation for a single user.
+ */
+export async function createEricConversationForUser(
+  db: Database,
+  agentId: string,
+  userId: string,
+): Promise<string> {
+  const convId = crypto.randomUUID();
+  await db.insert(conversations).values({
+    id: convId,
+    name: "Eric",
+    type: "ai",
+    agentId,
+  });
+  await db.insert(conversationMembers).values({
+    conversationId: convId,
+    userId,
+  });
+  return convId;
+}
+
+/**
+ * Creates the default Eric agent and one private AI conversation per existing user
  * when the workspace has no Eric yet (e.g. after db:seed without setup wizard).
  */
 export async function ensureDefaultEricWorkspace(db: Database): Promise<void> {
@@ -28,36 +50,37 @@ export async function ensureDefaultEricWorkspace(db: Database): Promise<void> {
     createdBy,
   });
 
-  const convId = crypto.randomUUID();
-  await db.insert(conversations).values({
-    id: convId,
-    name: "Eric",
-    type: "ai",
-    agentId: ericId,
-  });
-
+  // Create one private conversation per user
   const everyone = await db.select({ id: users.id }).from(users);
-  if (everyone.length === 0) return;
-
-  await db
-    .insert(conversationMembers)
-    .values(everyone.map((u) => ({ conversationId: convId, userId: u.id })))
-    .onConflictDoNothing();
+  for (const user of everyone) {
+    await createEricConversationForUser(db, ericId, user.id);
+  }
 }
 
-/** Adds a user to the default Eric AI conversation when it exists (single workspace assistant). */
-export async function addUserToEricConversation(db: Database, userId: string): Promise<void> {
-  const [ericConv] = await db
+/**
+ * Ensures a user has their own private Eric AI conversation.
+ * Creates one if it doesn't exist yet. Returns the conversation ID, or null if Eric agent is missing.
+ */
+export async function ensureEricConversationForUser(db: Database, userId: string): Promise<string | null> {
+  const [ericAgent] = await db.select({ id: agents.id }).from(agents).where(eq(agents.slug, "eric")).limit(1);
+  if (!ericAgent) return null;
+
+  // Check if this user already has their own Eric conversation
+  const existing = await db
     .select({ id: conversations.id })
     .from(conversations)
-    .innerJoin(agents, eq(conversations.agentId, agents.id))
-    .where(and(eq(agents.slug, "eric"), eq(conversations.type, "ai")))
+    .innerJoin(conversationMembers, eq(conversations.id, conversationMembers.conversationId))
+    .where(
+      and(
+        eq(conversations.agentId, ericAgent.id),
+        eq(conversations.type, "ai"),
+        eq(conversationMembers.userId, userId),
+      ),
+    )
     .limit(1);
 
-  if (!ericConv) return;
+  if (existing.length > 0) return existing[0].id;
 
-  await db
-    .insert(conversationMembers)
-    .values({ conversationId: ericConv.id, userId })
-    .onConflictDoNothing();
+  // Create new private conversation
+  return createEricConversationForUser(db, ericAgent.id, userId);
 }

--- a/apps/api/src/trpc/routers/settings.ts
+++ b/apps/api/src/trpc/routers/settings.ts
@@ -8,6 +8,7 @@ import { slugify, serializeFields, type EntityField } from "../../db/entity-fiel
 import { auth } from "../../auth/index.js";
 import { runBackgroundQuery as runBackgroundQueryFn } from "../../ai/background-query.js";
 import { getSkillsForRoutines } from "../../ai/skill-templates.js";
+import { createEricConversationForUser } from "../../services/eric-conversation.js";
 
 // Niche display names per locale (keyed by niche ID)
 const NICHE_NAMES: Record<string, Record<string, string>> = {
@@ -391,22 +392,12 @@ export const settingsRouter = router({
         createdBy: ctx.session.user.id,
       });
 
-      // Create the default Eric conversation
-      const convId = crypto.randomUUID();
-      await ctx.db.insert(conversations).values({
-        id: convId,
-        name: "Eric",
-        type: "ai",
-        agentId: ericId,
-      });
-      await ctx.db.insert(conversationMembers).values({
-        conversationId: convId,
-        userId: ctx.session.user.id,
-      });
-      if (invitedUserIds.length > 0) {
-        await ctx.db.insert(conversationMembers).values(
-          invitedUserIds.map((userId) => ({ conversationId: convId, userId })),
-        );
+      // Create a private Eric conversation for the setup user
+      const setupConvId = await createEricConversationForUser(ctx.db, ericId, ctx.session.user.id);
+
+      // Create a private Eric conversation for each invited user
+      for (const userId of invitedUserIds) {
+        await createEricConversationForUser(ctx.db, ericId, userId);
       }
 
       // Send a kickoff message so Eric starts researching the company (in the user's language)
@@ -415,7 +406,7 @@ export const settingsRouter = router({
       const msgId = crypto.randomUUID();
       await ctx.db.insert(messages).values({
         id: msgId,
-        conversationId: convId,
+        conversationId: setupConvId,
         authorId: ctx.session.user.id,
         content: kickoffContent,
         role: "user",
@@ -423,7 +414,7 @@ export const settingsRouter = router({
 
       // Trigger AI analysis in background
       runBackgroundQueryFn({
-        conversationId: convId,
+        conversationId: setupConvId,
         prompt: kickoffContent,
         userId: ctx.session.user.id,
       }).catch((err: unknown) => console.error("Setup AI kickoff error:", err));

--- a/apps/api/src/trpc/routers/users.ts
+++ b/apps/api/src/trpc/routers/users.ts
@@ -4,7 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../index.js";
 import { users, conversations, conversationMembers } from "../../db/schema/index.js";
 import { auth } from "../../auth/index.js";
-import { addUserToEricConversation } from "../../services/eric-conversation.js";
+import { ensureEricConversationForUser } from "../../services/eric-conversation.js";
 
 const isAdminOrOwner = (role: string) => role === "admin" || role === "owner";
 
@@ -67,7 +67,7 @@ export const usersRouter = router({
         { conversationId: dmId, userId: res.user.id },
       ]);
 
-      await addUserToEricConversation(ctx.db, res.user.id);
+      await ensureEricConversationForUser(ctx.db, res.user.id);
 
       return { id: res.user.id, email: input.email };
     }),


### PR DESCRIPTION
## Summary
- Each user now gets their own private Eric AI conversation instead of sharing a single one
- The Eric agent remains a single instance, but each user has an independent conversation with their own session/context
- `ensureEricConversationForUser` replaces `addUserToEricConversation`, creating a new conversation if the user doesn't have one yet

## Changed files
- `apps/api/src/services/eric-conversation.ts` - Rewrote to per-user conversation model with `createEricConversationForUser` and `ensureEricConversationForUser`
- `apps/api/src/trpc/routers/settings.ts` - Setup wizard creates one conversation per user instead of shared
- `apps/api/src/trpc/routers/users.ts` - Updated to use `ensureEricConversationForUser`
- `apps/api/src/scripts/provision-staging-users.ts` - Updated to use new function names

## Test plan
- [ ] Run setup wizard and verify the setup user gets their own Eric conversation
- [ ] Invite a second user and verify they get a separate Eric conversation
- [ ] Confirm messages sent to Eric by user A are not visible to user B
- [ ] Run `provision-staging-users` script and verify each user gets their own conversation