### PR TITLE
fix: enable workflow node editing and add execute button

### DIFF
--- a/apps/web/src/components/organisms/WorkflowCanvas/WorkflowCanvas.tsx
+++ b/apps/web/src/components/organisms/WorkflowCanvas/WorkflowCanvas.tsx
@@ -486,6 +486,7 @@ export interface WorkflowCanvasProps {
   readOnly?: boolean
   onNodeDelete?: (nodeId: string) => void
   onNodeEdit?: (nodeId: string, data: Record<string, unknown>) => void
+  onNodeAdd?: (node: Node) => void
 }
 
 export function WorkflowCanvas({
@@ -497,6 +498,7 @@ export function WorkflowCanvas({
   readOnly = false,
   onNodeDelete,
   onNodeEdit,
+  onNodeAdd,
 }: WorkflowCanvasProps) {
   const { t } = useTranslation()
   const [localNodes, setLocalNodes] = useState<Node[]>(nodesProp)
@@ -581,8 +583,9 @@ export function WorkflowCanvas({
       data: { label: type.charAt(0).toUpperCase() + type.slice(1), description: '' },
     }
     setLocalNodes((prev) => [...prev, newNode])
+    onNodeAdd?.(newNode)
     setPaneMenu(null)
-  }, [paneMenu])
+  }, [paneMenu, onNodeAdd])
 
   return (
     <div

--- a/apps/web/src/components/screens/WorkflowsScreen/WorkflowsScreen.tsx
+++ b/apps/web/src/components/screens/WorkflowsScreen/WorkflowsScreen.tsx
@@ -8,7 +8,7 @@ import {
   type Node,
   type Edge,
 } from '@xyflow/react'
-import { GitBranch, Clock, Pause, Play, MoreHorizontal } from 'lucide-react'
+import { GitBranch, Clock, Pause, Play, MoreHorizontal, Loader2 } from 'lucide-react'
 import { WorkflowSidebar, type Workflow } from '../../organisms/WorkflowSidebar/WorkflowSidebar'
 import { WorkflowCanvas } from '../../organisms/WorkflowCanvas/WorkflowCanvas'
 import { HistoryEntry, type HistoryEntryProps } from '../../molecules/HistoryEntry/HistoryEntry'
@@ -32,6 +32,8 @@ export interface WorkflowsScreenProps {
   onDeleteWorkflow?: (id: string) => void
   onDuplicateWorkflow?: (id: string) => void
   onGraphChange?: (workflowId: string, graph: WorkflowGraph) => void
+  onExecute?: (id: string) => void
+  isExecuting?: boolean
 }
 
 export function WorkflowsScreen({
@@ -46,6 +48,8 @@ export function WorkflowsScreen({
   onDeleteWorkflow,
   onDuplicateWorkflow,
   onGraphChange,
+  onExecute,
+  isExecuting = false,
 }: WorkflowsScreenProps) {
   const { t } = useTranslation()
   const [workflows, setWorkflows] = useState<Workflow[]>(workflowsProp)
@@ -97,6 +101,21 @@ export function WorkflowsScreen({
   const onConnect = useCallback(
     (params: Connection) => setEdges((eds) => addEdge(params, eds)),
     [setEdges]
+  )
+
+  const handleNodeAdd = useCallback(
+    (node: Node) => {
+      setNodes((prev) => [...prev, node])
+    },
+    [setNodes]
+  )
+
+  const handleNodeDelete = useCallback(
+    (nodeId: string) => {
+      setNodes((prev) => prev.filter((n) => n.id !== nodeId))
+      setEdges((prev) => prev.filter((e) => e.source !== nodeId && e.target !== nodeId))
+    },
+    [setNodes, setEdges]
   )
 
   // Debounced graph save
@@ -242,6 +261,28 @@ export function WorkflowsScreen({
             </button>
 
             <button
+              onClick={() => onExecute?.(selectedWf.id)}
+              disabled={isExecuting}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+                padding: '5px 12px',
+                background: 'var(--accent)',
+                border: 'none',
+                borderRadius: 6,
+                color: '#fff',
+                fontSize: 12,
+                fontWeight: 500,
+                cursor: isExecuting ? 'not-allowed' : 'pointer',
+                opacity: isExecuting ? 0.7 : 1,
+                fontFamily: 'inherit',
+              }}
+            >
+              {isExecuting ? <Loader2 size={12} style={{ animation: 'spin 1s linear infinite' }} /> : <Play size={12} />} {t('workflows.run')}
+            </button>
+
+            <button
               onClick={() => onToggleStatus?.(selectedWf.id)}
               style={{
                 display: 'flex',
@@ -340,6 +381,8 @@ export function WorkflowsScreen({
               onNodesChange={onNodesChange}
               onEdgesChange={onEdgesChange}
               onConnect={onConnect}
+              onNodeAdd={handleNodeAdd}
+              onNodeDelete={handleNodeDelete}
             />
           </div>
 

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -610,6 +610,7 @@ const en = {
     workflowOptions: 'Workflow options',
     deleteWorkflow: 'Delete workflow',
     duplicateWorkflow: 'Duplicate workflow',
+    run: 'Run',
     noExecutions: 'No executions recorded',
     displayName: 'Display Name',
     triggerType: 'Trigger Type',

--- a/apps/web/src/locales/pt-BR.ts
+++ b/apps/web/src/locales/pt-BR.ts
@@ -608,6 +608,7 @@ const ptBR = {
     workflowOptions: 'Opções do workflow',
     deleteWorkflow: 'Excluir workflow',
     duplicateWorkflow: 'Duplicar workflow',
+    run: 'Executar',
     noExecutions: 'Nenhuma execução registrada',
     displayName: 'Nome de Exibição',
     triggerType: 'Tipo de Gatilho',

--- a/apps/web/src/pages/WorkflowsPage.tsx
+++ b/apps/web/src/pages/WorkflowsPage.tsx
@@ -229,6 +229,8 @@ export function WorkflowsPage() {
         onDuplicateWorkflow={handleDuplicateWorkflow}
         onAISend={handleAISend}
         onGraphChange={(workflowId, graph) => saveGraphMut.mutate({ id: workflowId, graph })}
+        onExecute={(id) => executeMut.mutate({ id })}
+        isExecuting={executeMut.isPending}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- **#23**: Wire `onNodeAdd` and `onNodeDelete` callbacks from `WorkflowCanvas` through `WorkflowsScreen` so adding nodes (right-click context menu) and deleting nodes (hover X button) properly update the parent state and trigger the debounced auto-save via `onGraphChange`.
- **#24**: Add a "Run" execute button (Play icon) to the workflow header, between History and Pause/Activate. Wired to `executeMut.mutate({ id })` with loading spinner state.

Closes #23, closes #24.

## Test plan
- [ ] Select a workflow, right-click canvas to add nodes, verify they persist after reload
- [ ] Hover a node, click X to delete, verify the node and its edges are removed and saved
- [ ] Click the "Run" button in the header, verify execution starts and history updates
- [ ] Verify the Run button shows a spinner while executing
- [ ] Verify no regressions with Pause/Activate and History panel