### PR TITLE
fix: wire DataGrid column ops, row detail panel, and inline new row

### DIFF
--- a/apps/web/src/components/organisms/DataGrid/DataGrid.tsx
+++ b/apps/web/src/components/organisms/DataGrid/DataGrid.tsx
@@ -42,6 +42,7 @@ export function DataGrid({
   onGroupByChange: externalGroupByChange,
   filterConfig: externalFilterConfig,
   onFilterChange: externalFilterChange,
+  inlineNewRow,
   toolbarLeftSlot,
   onAIGenerate,
   onFetchRelationshipRecords,
@@ -281,12 +282,9 @@ export function DataGrid({
   const selectedIds = Array.from(allSelectedIds)
   const detailRow = detailRowId ? mergedRows.find(r => getRowId(r) === detailRowId) ?? null : null
 
-  const _handleRowClickForDetail = (rowId: string, col: GridColumn) => {
-    // If clicking on a cell that is not the ID column and not an editable action, open detail panel
-    if (onRowClick) {
-      onRowClick(rowId)
-    }
-    handleCellClick(rowId, col)
+  const handleRowDoubleClick = (rowId: string) => {
+    setDetailRowId(rowId)
+    onRowClick?.(rowId)
   }
 
   const handleClearSelection = () => {
@@ -345,7 +343,11 @@ export function DataGrid({
               onSortDesc={handleSortDesc}
               onHideColumn={state.toggleColumn}
               onStartResize={startResize}
-              onColumnRename={onColumnRename ? (colId) => onColumnRename(colId, '') : undefined}
+              onColumnRename={onColumnRename ? (colId) => {
+                const col = columns.find(c => c.id === colId)
+                const newName = window.prompt('Rename column:', col?.label ?? colId)
+                if (newName && newName.trim()) onColumnRename(colId, newName.trim())
+              } : undefined}
               onColumnDelete={onColumnDelete}
               onColumnInsert={onColumnInsert}
             />
@@ -380,6 +382,8 @@ export function DataGrid({
               onFetchRelationshipRecords={onFetchRelationshipRecords}
               workspaceUsers={workspaceUsers}
               onAIGenerate={onAIGenerate}
+              onRowDoubleClick={handleRowDoubleClick}
+              inlineNewRow={inlineNewRow}
             />
           </div>
         </ScrollArea.Viewport>

--- a/apps/web/src/components/organisms/DataGrid/parts/GridBody.tsx
+++ b/apps/web/src/components/organisms/DataGrid/parts/GridBody.tsx
@@ -41,6 +41,7 @@ interface GridBodyProps {
   onFetchRelationshipRecords?: (entityId: string, search: string) => Promise<{ id: string; label: string }[]>
   workspaceUsers?: { id: string; name: string; avatar?: string }[]
   onAIGenerate?: (rowId: string, colId: string, prompt: string) => Promise<string>
+  onRowDoubleClick?: (rowId: string) => void
   inlineNewRow?: {
     isActive: boolean
     values: Record<string, string>
@@ -81,6 +82,7 @@ export function GridBody({
   onFetchRelationshipRecords,
   workspaceUsers,
   onAIGenerate,
+  onRowDoubleClick,
   inlineNewRow,
 }: GridBodyProps) {
   const showSkeleton = visibleRows.length === 0 && !emptyMessage
@@ -114,6 +116,7 @@ export function GridBody({
         onFetchRelationshipRecords={onFetchRelationshipRecords}
         workspaceUsers={workspaceUsers}
         onAIGenerate={onAIGenerate}
+        onDoubleClick={onRowDoubleClick}
       />
     )
   }

--- a/apps/web/src/components/organisms/DataGrid/parts/GridRow.tsx
+++ b/apps/web/src/components/organisms/DataGrid/parts/GridRow.tsx
@@ -30,6 +30,7 @@ interface GridRowProps {
   onFetchRelationshipRecords?: (entityId: string, search: string) => Promise<{ id: string; label: string }[]>
   workspaceUsers?: { id: string; name: string; avatar?: string }[]
   onAIGenerate?: (rowId: string, colId: string, prompt: string) => Promise<string>
+  onDoubleClick?: (rowId: string) => void
 }
 
 export function GridRow({
@@ -57,6 +58,7 @@ export function GridRow({
   onFetchRelationshipRecords,
   workspaceUsers,
   onAIGenerate,
+  onDoubleClick,
 }: GridRowProps) {
   const { t } = useTranslation()
   return (
@@ -76,6 +78,7 @@ export function GridRow({
       }}
       onMouseEnter={() => onHover(rowId)}
       onMouseLeave={() => onHover(null)}
+      onDoubleClick={() => onDoubleClick?.(rowId)}
     >
       <div role="cell" style={{ width: 40, padding: '9px 12px', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
         <input

--- a/apps/web/src/components/organisms/DataGrid/types.ts
+++ b/apps/web/src/components/organisms/DataGrid/types.ts
@@ -124,6 +124,15 @@ export interface DataGridProps {
   onAIGenerate?: (rowId: string, colId: string, prompt: string) => Promise<string>
   groupByColumn?: string
   onGroupByChange?: (colId: string | null) => void
+  /** Inline new row state and callbacks */
+  inlineNewRow?: {
+    isActive: boolean
+    values: Record<string, string>
+    onStart: () => void
+    onValueChange: (colId: string, value: string) => void
+    onCommit: () => void
+    onCancel: () => void
+  }
   /** Optional slot rendered at the start of the toolbar (e.g. ViewSwitcher) */
   toolbarLeftSlot?: React.ReactNode
   /** Callback to fetch records from a related entity (for relationship cells) */

--- a/apps/web/src/components/screens/DatabaseScreen/DatabaseScreen.tsx
+++ b/apps/web/src/components/screens/DatabaseScreen/DatabaseScreen.tsx
@@ -60,6 +60,19 @@ export interface DatabaseScreenProps {
   onAddEntityField?: (entityId: string, field: Omit<EntityField, 'id'>) => void
   onUpdateEntityField?: (entityId: string, fieldId: string, updates: Partial<EntityField>) => void
   onDeleteEntityField?: (entityId: string, fieldId: string) => void
+  // DataGrid column operations (Issue #10)
+  onColumnRename?: (colId: string, newLabel: string) => void
+  onColumnDelete?: (colId: string) => void
+  onColumnInsert?: (position: 'left' | 'right', referenceColId: string) => void
+  // DataGrid inline new row (Issue #16)
+  inlineNewRow?: {
+    isActive: boolean
+    values: Record<string, string>
+    onStart: () => void
+    onValueChange: (colId: string, value: string) => void
+    onCommit: () => void
+    onCancel: () => void
+  }
   // DataGrid advanced cell props
   onFetchRelationshipRecords?: (entityId: string, search: string) => Promise<{ id: string; label: string }[]>
   workspaceUsers?: { id: string; name: string; avatar?: string }[]
@@ -97,6 +110,10 @@ export function DatabaseScreen({
   onAddEntityField,
   onUpdateEntityField,
   onDeleteEntityField,
+  onColumnRename,
+  onColumnDelete,
+  onColumnInsert,
+  inlineNewRow,
   onFetchRelationshipRecords,
   workspaceUsers,
   onAIGenerate,
@@ -239,6 +256,10 @@ export function DatabaseScreen({
               selectedRows={selectedRows}
               groups={groups}
               onToggleGroup={onToggleGroup}
+              onColumnRename={onColumnRename}
+              onColumnDelete={onColumnDelete}
+              onColumnInsert={onColumnInsert}
+              inlineNewRow={inlineNewRow}
               onFetchRelationshipRecords={onFetchRelationshipRecords}
               workspaceUsers={workspaceUsers}
               onAIGenerate={onAIGenerate}

--- a/apps/web/src/pages/DatabasePage.tsx
+++ b/apps/web/src/pages/DatabasePage.tsx
@@ -183,6 +183,10 @@ export function DatabasePage() {
   const [showNewRecord, setShowNewRecord] = useState(false);
   const [newRecordData, setNewRecordData] = useState<Record<string, string>>({});
 
+  // Inline new row state (Issue #16)
+  const [inlineNewRowActive, setInlineNewRowActive] = useState(false);
+  const [inlineNewRowValues, setInlineNewRowValues] = useState<Record<string, string>>({});
+
   // AI chat for database context
   const createContextConv = trpc.conversations.getOrCreateContext.useMutation();
   const sendAI = trpc.messages.send.useMutation();
@@ -553,6 +557,79 @@ export function DatabasePage() {
     [activeEntityId, fields, generateFieldValue],
   );
 
+  // Issue #10: Column rename callback
+  const handleColumnRename = useCallback(
+    (colId: string, newLabel: string) => {
+      if (!activeEntityId || !newLabel) return;
+      const field = fields.find((f) => f.slug === colId);
+      if (!field) return;
+      updateField.mutate({
+        entityId: activeEntityId,
+        fieldId: field.id,
+        updates: { name: newLabel },
+      });
+    },
+    [activeEntityId, fields, updateField],
+  );
+
+  // Issue #10: Column delete callback
+  const handleColumnDelete = useCallback(
+    (colId: string) => {
+      if (!activeEntityId) return;
+      const field = fields.find((f) => f.slug === colId);
+      if (!field) return;
+      const confirmed = window.confirm(`Delete column "${field.name}"? This cannot be undone.`);
+      if (!confirmed) return;
+      removeField.mutate({ entityId: activeEntityId, fieldId: field.id });
+    },
+    [activeEntityId, fields, removeField],
+  );
+
+  // Issue #10: Column insert callback (opens AddField dialog)
+  const handleColumnInsert = useCallback(
+    (_position: 'left' | 'right', _referenceColId: string) => {
+      setShowAddField(true);
+    },
+    [],
+  );
+
+  // Issue #16: Inline new row commit
+  const handleInlineNewRowCommit = useCallback(() => {
+    if (!activeEntityId) return;
+    const data: Record<string, unknown> = {};
+    for (const field of fields) {
+      const val = inlineNewRowValues[field.slug];
+      if (val === undefined || val === "") continue;
+      if (field.type === "number" || field.type === "decimal" || field.type === "currency" || field.type === "percent" || field.type === "duration") {
+        data[field.slug] = Number(val);
+      } else if (field.type === "checkbox") {
+        data[field.slug] = val === "true";
+      } else if (field.type === "rating") {
+        data[field.slug] = Number(val);
+      } else {
+        data[field.slug] = val;
+      }
+    }
+    if (Object.keys(data).length > 0) {
+      createRecord.mutate({ entityId: activeEntityId, data });
+    }
+    setInlineNewRowActive(false);
+    setInlineNewRowValues({});
+  }, [activeEntityId, fields, inlineNewRowValues, createRecord]);
+
+  const inlineNewRow = useMemo(() => ({
+    isActive: inlineNewRowActive,
+    values: inlineNewRowValues,
+    onStart: () => setInlineNewRowActive(true),
+    onValueChange: (colId: string, value: string) =>
+      setInlineNewRowValues((prev) => ({ ...prev, [colId]: value })),
+    onCommit: handleInlineNewRowCommit,
+    onCancel: () => {
+      setInlineNewRowActive(false);
+      setInlineNewRowValues({});
+    },
+  }), [inlineNewRowActive, inlineNewRowValues, handleInlineNewRowCommit]);
+
   if (entitiesQuery.isSuccess && entities.length === 0) {
     return (
       <div
@@ -619,6 +696,10 @@ export function DatabasePage() {
         onAddEntityField={handleManageAddField}
         onUpdateEntityField={handleManageUpdateField}
         onDeleteEntityField={handleManageDeleteField}
+        onColumnRename={handleColumnRename}
+        onColumnDelete={handleColumnDelete}
+        onColumnInsert={handleColumnInsert}
+        inlineNewRow={inlineNewRow}
         onFetchRelationshipRecords={handleFetchRelationshipRecords}
         workspaceUsers={workspaceUsers}
         onAIGenerate={handleAIGenerate}


### PR DESCRIPTION
## Summary

- **#10 Column rename/delete/insert**: Wires `onColumnRename` (calls `trpc.entities.updateField` with a prompt for the new name), `onColumnDelete` (calls `trpc.entities.removeField` with a confirmation dialog), and `onColumnInsert` (opens the existing AddField dialog). Callbacks flow from DatabasePage through DatabaseScreen to DataGrid.
- **#15 Row detail panel**: Double-clicking a row now sets `detailRowId` which renders the existing `RowDetailPanel` as a slide-in panel. Added `onDoubleClick` prop to GridRow, passed through GridBody.
- **#16 Inline new row**: Wires the existing `InlineNewRow` component via the `inlineNewRow` prop on DataGrid. Typing values and pressing Enter calls `createRecord` mutation. State is managed in DatabasePage and passed through.

Closes #10, closes #15, closes #16.

## Test plan
- [ ] Open Database page, right-click a column header: Rename prompts for new name, Delete asks confirmation, Insert Left/Right opens AddField dialog
- [ ] Double-click a row to open the detail panel on the right, close it with the X button
- [ ] Click "+ Record" at the bottom of the grid, type values, press Enter to create a record
- [ ] Verify existing functionality (cell editing, sorting, filtering, bulk actions) still works