### PR TITLE
fix: task search, workflow node config, mail attachments, tool test

### DIFF
--- a/apps/api/src/email/provider.ts
+++ b/apps/api/src/email/provider.ts
@@ -30,6 +30,7 @@ export interface SendMailOptions {
   fromName?: string;
   replyTo?: string;
   inReplyTo?: string;
+  attachments?: { filename: string; path: string; contentType?: string }[];
 }
 
 export interface SendMailResult {
@@ -205,6 +206,7 @@ export async function sendMailWithConfig(config: SmtpConfig, options: SendMailOp
     text: options.bodyText,
     replyTo: options.replyTo,
     inReplyTo: options.inReplyTo,
+    attachments: options.attachments,
   });
 
   return {

--- a/apps/api/src/trpc/routers/custom-tools.ts
+++ b/apps/api/src/trpc/routers/custom-tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { eq } from "drizzle-orm";
+import Anthropic from "@anthropic-ai/sdk";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../index.js";
 import { customTools } from "../../db/schema/index.js";
@@ -130,6 +131,50 @@ export const customToolsRouter = router({
 
       if (!toolRow) throw new TRPCError({ code: "NOT_FOUND" });
 
-      return { success: false, error: "AI layer not available" };
+      if (!process.env.ANTHROPIC_API_KEY) {
+        throw new TRPCError({ code: "PRECONDITION_FAILED", message: "ANTHROPIC_API_KEY is not configured." });
+      }
+
+      let inputSchema: Record<string, unknown>;
+      try {
+        inputSchema = JSON.parse(toolRow.inputSchema);
+      } catch {
+        return { success: false, error: "Tool has invalid inputSchema JSON" };
+      }
+
+      const toolDef: Anthropic.Tool = {
+        name: toolRow.name,
+        description: toolRow.description,
+        input_schema: inputSchema as Anthropic.Tool["input_schema"],
+      };
+
+      const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+      try {
+        const response = await anthropic.messages.create({
+          model: "claude-sonnet-4-6",
+          max_tokens: 1024,
+          tools: [toolDef],
+          messages: [
+            {
+              role: "user",
+              content: `Use the "${toolRow.name}" tool with this input: ${JSON.stringify(input.testInput)}`,
+            },
+          ],
+        });
+
+        const toolUseBlock = response.content.find((b) => b.type === "tool_use");
+        if (toolUseBlock && toolUseBlock.type === "tool_use") {
+          return { success: true, result: toolUseBlock.input as Record<string, unknown> };
+        }
+
+        const textBlock = response.content.find((b) => b.type === "text");
+        return {
+          success: true,
+          result: { response: textBlock && textBlock.type === "text" ? textBlock.text : "No tool invocation" },
+        };
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : "AI call failed" };
+      }
     }),
 });

--- a/apps/api/src/trpc/routers/emails.ts
+++ b/apps/api/src/trpc/routers/emails.ts
@@ -300,6 +300,12 @@ export const emailsRouter = router({
       cc: z.string().optional(),
       subject: z.string(),
       body: z.string(),
+      attachments: z.array(z.object({
+        id: z.string(),
+        name: z.string(),
+        path: z.string(),
+        mimeType: z.string().optional(),
+      })).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       const { userCanSendFrom, sendMailFromAccount, getAccountSmtpConfig } = await import("../../email/provider.js");
@@ -314,11 +320,23 @@ export const emailsRouter = router({
       const toAddresses = input.to.split(",").map((e) => e.trim()).filter(Boolean);
       const ccAddresses = input.cc ? input.cc.split(",").map((e) => e.trim()).filter(Boolean) : [];
 
+      // Build nodemailer-compatible attachment list from uploaded file paths
+      let mailAttachments: { filename: string; path: string; contentType?: string }[] | undefined;
+      if (input.attachments && input.attachments.length > 0) {
+        const { localStorage: fileStorage } = await import("../../files/storage.js");
+        mailAttachments = input.attachments.map((att) => ({
+          filename: att.name,
+          path: fileStorage.getFilePath(att.path),
+          contentType: att.mimeType || undefined,
+        }));
+      }
+
       const result = await sendMailFromAccount(ctx.db, input.accountId, {
         to: toAddresses,
         cc: ccAddresses,
         subject: input.subject,
         bodyHtml: input.body,
+        attachments: mailAttachments,
       });
 
       const emailId = await storeSentEmail(ctx.db, {

--- a/apps/web/src/components/organisms/MailCompose/MailCompose.tsx
+++ b/apps/web/src/components/organisms/MailCompose/MailCompose.tsx
@@ -1,9 +1,17 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import {
   X, Paperclip, Sparkles, Minimize2, Maximize2,
 } from 'lucide-react'
 import { Button } from '../../atoms/Button/Button'
 import { useTranslation } from 'react-i18next'
+
+export interface MailAttachmentMeta {
+  id: string
+  name: string
+  size: string
+  path: string
+  mimeType?: string
+}
 
 export interface MailComposeProps {
   open: boolean
@@ -12,7 +20,7 @@ export interface MailComposeProps {
   body?: string
   replyMode?: 'reply' | 'replyAll' | 'forward'
   onClose?: () => void
-  onSend?: (data: { to: string; cc: string; subject: string; body: string }) => void
+  onSend?: (data: { to: string; cc: string; subject: string; body: string; attachments?: MailAttachmentMeta[] }) => void
   onAiDraft?: (prompt: string) => void
   aiDrafting?: boolean
   minimized?: boolean
@@ -40,17 +48,45 @@ export function MailCompose({
   const [showCc, setShowCc] = useState(false)
   const [aiPrompt, setAiPrompt] = useState('')
   const [showAiBar, setShowAiBar] = useState(false)
+  const [attachments, setAttachments] = useState<MailAttachmentMeta[]>([])
+  const [uploading, setUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   React.useEffect(() => {
     setTo(initialTo)
     setSubject(initialSubject)
     setBody(initialBody)
+    setAttachments([])
   }, [initialTo, initialSubject, initialBody])
 
   if (!open) return null
 
   const handleSend = () => {
-    onSend?.({ to, cc, subject, body })
+    onSend?.({ to, cc, subject, body, attachments: attachments.length > 0 ? attachments : undefined })
+  }
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+    setUploading(true)
+    try {
+      for (const file of Array.from(files)) {
+        const formData = new FormData()
+        formData.append('file', file)
+        const res = await fetch('/api/upload/file', { method: 'POST', body: formData, credentials: 'include' })
+        if (res.ok) {
+          const data = await res.json()
+          setAttachments((prev) => [...prev, { id: data.id, name: data.name, size: data.size, path: data.path, mimeType: data.mimeType }])
+        }
+      }
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const handleRemoveAttachment = (id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
   const handleAiDraft = () => {
@@ -173,6 +209,39 @@ export function MailCompose({
             </div>
           </div>
 
+          {/* Attachments */}
+          {attachments.length > 0 && (
+            <div style={{ padding: '6px 14px 0', display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {attachments.map((att) => (
+                <div
+                  key={att.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '3px 8px',
+                    borderRadius: 6,
+                    background: 'var(--surface-2)',
+                    border: '1px solid var(--border)',
+                    fontSize: 11,
+                    color: 'var(--text)',
+                  }}
+                >
+                  <Paperclip size={11} color="var(--text-muted)" />
+                  <span style={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{att.name}</span>
+                  <span style={{ color: 'var(--text-muted)', fontSize: 10 }}>({att.size})</span>
+                  <button
+                    onClick={() => handleRemoveAttachment(att.id)}
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 1, display: 'flex', color: 'var(--text-muted)' }}
+                    aria-label={t('remove')}
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
           {/* Body */}
           <textarea
             value={body}
@@ -250,9 +319,26 @@ export function MailCompose({
             >
               <Sparkles size={14} />
             </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileSelect}
+              style={{ display: 'none' }}
+            />
             <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
               title={t('mail.attachFile')}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 6, display: 'flex', color: 'var(--text-muted)' }}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: uploading ? 'wait' : 'pointer',
+                padding: 6,
+                display: 'flex',
+                color: 'var(--text-muted)',
+                opacity: uploading ? 0.5 : 1,
+              }}
             >
               <Paperclip size={14} />
             </button>

--- a/apps/web/src/components/organisms/WorkflowCanvas/WorkflowCanvas.tsx
+++ b/apps/web/src/components/organisms/WorkflowCanvas/WorkflowCanvas.tsx
@@ -487,6 +487,7 @@ export interface WorkflowCanvasProps {
   onNodeDelete?: (nodeId: string) => void
   onNodeEdit?: (nodeId: string, data: Record<string, unknown>) => void
   onNodeAdd?: (node: Node) => void
+  onNodeClick?: (event: React.MouseEvent, node: Node) => void
 }
 
 export function WorkflowCanvas({
@@ -499,6 +500,7 @@ export function WorkflowCanvas({
   onNodeDelete,
   onNodeEdit,
   onNodeAdd,
+  onNodeClick,
 }: WorkflowCanvasProps) {
   const { t } = useTranslation()
   const [localNodes, setLocalNodes] = useState<Node[]>(nodesProp)
@@ -604,6 +606,7 @@ export function WorkflowCanvas({
         nodesDraggable={!readOnly}
         nodesConnectable={!readOnly}
         elementsSelectable={!readOnly}
+        onNodeClick={onNodeClick}
         onPaneContextMenu={readOnly ? undefined : handlePaneContextMenu}
         fitView
         fitViewOptions={{ padding: 0.3 }}

--- a/apps/web/src/components/screens/MailScreen/MailScreen.tsx
+++ b/apps/web/src/components/screens/MailScreen/MailScreen.tsx
@@ -7,7 +7,7 @@ import {
 import { MailFolderItem } from '../../molecules/MailFolderItem/MailFolderItem'
 import { MailList } from '../../organisms/MailList/MailList'
 import { MailDetail, type MailMessage, type MailAttachment } from '../../organisms/MailDetail/MailDetail'
-import { MailCompose } from '../../organisms/MailCompose/MailCompose'
+import { MailCompose, type MailAttachmentMeta } from '../../organisms/MailCompose/MailCompose'
 import { EmailSetup, type EmailAccountConfig } from '../../organisms/EmailSetup/EmailSetup'
 import { Button } from '../../atoms/Button/Button'
 import type { MailItemProps } from '../../molecules/MailItem/MailItem'
@@ -60,7 +60,7 @@ export interface MailScreenProps {
   onEmailClick?: (id: string) => void
   onEmailStar?: (id: string) => void
   onCompose?: () => void
-  onSend?: (data: { to: string; cc: string; subject: string; body: string }) => void
+  onSend?: (data: { to: string; cc: string; subject: string; body: string; attachments?: MailAttachmentMeta[] }) => void
   onReply?: (emailId: string) => void
   onReplyAll?: (emailId: string) => void
   onForward?: (emailId: string) => void

--- a/apps/web/src/components/screens/TasksScreen/TasksScreen.tsx
+++ b/apps/web/src/components/screens/TasksScreen/TasksScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Search, X } from 'lucide-react'
 import * as ScrollArea from '@radix-ui/react-scroll-area'
 import { TaskList, type Task } from '../../organisms/TaskList/TaskList'
 
@@ -34,6 +35,7 @@ export function TasksScreen({
 }: TasksScreenProps) {
   const { t } = useTranslation()
   const [activeFilter, setActiveFilter] = useState(initialFilter)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const handleFilterChange = (id: string) => {
     setActiveFilter(id)
@@ -47,17 +49,25 @@ export function TasksScreen({
   const activeFilterItem = filters.find((f) => f.id === activeFilter)
   const isAgentFilter = activeFilterItem?.indent === true
 
-  // Pre-filter tasks in the screen so TaskList receives only the relevant subset.
-  // This keeps TaskList's own filter pills in uncontrolled mode and fully functional.
-  const visibleTasks = (() => {
-    if (isAgentFilter && activeFilterItem) return tasks.filter((t) => t.agent === activeFilterItem.label)
-    if (activeFilter === 'running') return tasks.filter((t) => t.status === 'running')
-    if (activeFilter === 'completed') return tasks.filter((t) => t.status === 'completed')
-    if (activeFilter === 'failed') return tasks.filter((t) => t.status === 'failed')
-    if (activeFilter === 'pending') return tasks.filter((t) => t.status === 'pending')
-    if (activeFilter === 'cancelled') return tasks.filter((t) => t.status === 'cancelled')
-    return tasks
-  })()
+  // Pre-filter tasks by sidebar filter, then by search query
+  const visibleTasks = useMemo(() => {
+    let filtered: Task[]
+    if (isAgentFilter && activeFilterItem) filtered = tasks.filter((t) => t.agent === activeFilterItem.label)
+    else if (activeFilter === 'running') filtered = tasks.filter((t) => t.status === 'running')
+    else if (activeFilter === 'completed') filtered = tasks.filter((t) => t.status === 'completed')
+    else if (activeFilter === 'failed') filtered = tasks.filter((t) => t.status === 'failed')
+    else if (activeFilter === 'pending') filtered = tasks.filter((t) => t.status === 'pending')
+    else if (activeFilter === 'cancelled') filtered = tasks.filter((t) => t.status === 'cancelled')
+    else filtered = tasks
+
+    if (!searchQuery.trim()) return filtered
+
+    const q = searchQuery.toLowerCase()
+    return filtered.filter((task) =>
+      task.title.toLowerCase().includes(q) ||
+      (task.description && task.description.toLowerCase().includes(q))
+    )
+  }, [tasks, activeFilter, isAgentFilter, activeFilterItem, searchQuery])
 
   const headerTitle = activeFilterItem && !activeFilterItem.isHeader
     ? activeFilterItem.label
@@ -185,6 +195,43 @@ export function TasksScreen({
           }}
         >
           <span style={{ fontWeight: 600, fontSize: 15 }}>{headerTitle}</span>
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '4px 10px',
+            borderRadius: 8,
+            border: '1px solid var(--border)',
+            background: 'var(--surface-2)',
+            flex: 1,
+            maxWidth: 320,
+            marginLeft: 16,
+          }}>
+            <Search size={14} color="var(--text-muted)" />
+            <input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('tasks.searchPlaceholder')}
+              style={{
+                flex: 1,
+                border: 'none',
+                background: 'transparent',
+                color: 'var(--text)',
+                fontSize: 13,
+                fontFamily: 'inherit',
+                outline: 'none',
+              }}
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, display: 'flex', color: 'var(--text-muted)' }}
+                aria-label={t('clear')}
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
           <div style={{ flex: 1 }} />
           <div style={{ display: 'flex', gap: 8 }}>
             {[

--- a/apps/web/src/components/screens/WorkflowsScreen/WorkflowsScreen.tsx
+++ b/apps/web/src/components/screens/WorkflowsScreen/WorkflowsScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { GitBranch, Clock, Pause, Play, MoreHorizontal, Loader2 } from 'lucide-react'
 import { WorkflowSidebar, type Workflow } from '../../organisms/WorkflowSidebar/WorkflowSidebar'
 import { WorkflowCanvas } from '../../organisms/WorkflowCanvas/WorkflowCanvas'
+import { NodeConfigPanel, type NodeConfigData } from '../../organisms/NodeConfigPanel/NodeConfigPanel'
 import { HistoryEntry, type HistoryEntryProps } from '../../molecules/HistoryEntry/HistoryEntry'
 import { AIChatBar } from '../../molecules/AIChatBar/AIChatBar'
 import * as ScrollArea from '@radix-ui/react-scroll-area'
@@ -34,6 +35,8 @@ export interface WorkflowsScreenProps {
   onGraphChange?: (workflowId: string, graph: WorkflowGraph) => void
   onExecute?: (id: string) => void
   isExecuting?: boolean
+  toolOptions?: { value: string; label: string }[]
+  agentOptions?: { value: string; label: string }[]
 }
 
 export function WorkflowsScreen({
@@ -50,6 +53,8 @@ export function WorkflowsScreen({
   onGraphChange,
   onExecute,
   isExecuting = false,
+  toolOptions = [],
+  agentOptions = [],
 }: WorkflowsScreenProps) {
   const { t } = useTranslation()
   const [workflows, setWorkflows] = useState<Workflow[]>(workflowsProp)
@@ -57,6 +62,7 @@ export function WorkflowsScreen({
     controlledId ?? workflowsProp[0]?.id
   )
   const [showHistory, setShowHistory] = useState(false)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [aiInput, setAiInput] = useState('')
   const [moreOpen, setMoreOpen] = useState(false)
   const moreRef = useRef<HTMLDivElement>(null)
@@ -114,8 +120,24 @@ export function WorkflowsScreen({
     (nodeId: string) => {
       setNodes((prev) => prev.filter((n) => n.id !== nodeId))
       setEdges((prev) => prev.filter((e) => e.source !== nodeId && e.target !== nodeId))
+      if (selectedNodeId === nodeId) setSelectedNodeId(null)
     },
-    [setNodes, setEdges]
+    [setNodes, setEdges, selectedNodeId]
+  )
+
+  const handleNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
+    setSelectedNodeId(node.id)
+  }, [])
+
+  const handleNodeConfigSave = useCallback(
+    (nodeId: string, data: NodeConfigData) => {
+      setNodes((prev) =>
+        prev.map((n) =>
+          n.id === nodeId ? { ...n, data: { ...n.data, ...data } } : n
+        )
+      )
+    },
+    [setNodes]
   )
 
   // Debounced graph save
@@ -383,8 +405,30 @@ export function WorkflowsScreen({
               onConnect={onConnect}
               onNodeAdd={handleNodeAdd}
               onNodeDelete={handleNodeDelete}
+              onNodeClick={handleNodeClick}
             />
           </div>
+
+          {selectedNodeId && (() => {
+            const selectedNode = nodes.find((n) => n.id === selectedNodeId)
+            if (!selectedNode) return null
+            return (
+              <NodeConfigPanel
+                nodeId={selectedNode.id}
+                nodeLabel={String(selectedNode.data?.label ?? '')}
+                initialData={{
+                  taskType: (selectedNode.data?.taskType as 'inference' | 'structured') ?? 'inference',
+                  toolName: selectedNode.data?.toolName as string | undefined,
+                  agentId: selectedNode.data?.agentId as string | undefined,
+                  toolInput: selectedNode.data?.toolInput as string | undefined,
+                }}
+                toolOptions={toolOptions}
+                agentOptions={agentOptions}
+                onSave={handleNodeConfigSave}
+                onClose={() => setSelectedNodeId(null)}
+              />
+            )
+          })()}
 
           {showHistory && (
             <div

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -591,6 +591,7 @@ const en = {
     retryTask: 'Retry task',
     cancelTask: 'Cancel task',
     runningTasksCount: 'Running tasks count',
+    searchPlaceholder: 'Search tasks...',
   },
 
   // Workflows

--- a/apps/web/src/locales/pt-BR.ts
+++ b/apps/web/src/locales/pt-BR.ts
@@ -589,6 +589,7 @@ const ptBR = {
     retryTask: 'Tentar novamente',
     cancelTask: 'Cancelar tarefa',
     runningTasksCount: 'Tarefas em execução',
+    searchPlaceholder: 'Buscar tarefas...',
   },
 
   // Workflows


### PR DESCRIPTION
## Summary

- **#20** Add search input to TasksScreen header that filters tasks client-side by title/description
- **#25** Wire NodeConfigPanel into WorkflowsScreen. Clicking a workflow node opens the config sidebar with task type, tool, agent, and JSON input fields. Saving updates the node data and triggers auto-save.
- **#36** Wire the paperclip button in MailCompose to open a file picker, upload via `/api/upload/file`, display attachment chips with remove, and pass attachment metadata through `onSend`. Update `emails.send` tRPC mutation and `SendMailOptions` to support nodemailer attachments.
- **#44** Replace the custom tool test stub with an actual Anthropic SDK call that sends the tool definition and test input to Claude, returning the tool invocation result.

Closes #20, closes #25, closes #36, closes #44

## Test plan
- [ ] TasksScreen: type in search bar, verify tasks filter by title/description
- [ ] WorkflowsScreen: click a node, verify config panel opens. Edit fields, save, verify node data updates.
- [ ] MailCompose: click paperclip, select files, verify they upload and appear as chips. Send with attachments.
- [ ] Settings > Custom Tools: click Test on a tool, verify it calls AI and returns result instead of error