### PR TITLE
feat(agent): add update_record and delete_record tools

### DIFF
--- a/apps/api/src/ai/prompts.ts
+++ b/apps/api/src/ai/prompts.ts
@@ -17,6 +17,8 @@ Rules:
 - Be efficient with tool calls. Do NOT repeat similar searches. If a search returns results, use them. Limit yourself to 3-5 web searches per request maximum.
 - Present results as soon as you have useful data. Do not over-research.
 - When asked to create or register a record, call insert_record immediately with the data provided.
+- When asked to edit, change, correct, or add information to an existing record, locate it with query_records and call update_record. Do not refuse edits.
+- When asked to delete or remove a record, call delete_record. The system will ask the user for confirmation before running.
 - Use list_entities to check what exists before creating new ones.
 
 For web research, ALWAYS use the web_search tool first to find URLs, then fetch_url to read specific pages. NEVER guess or fabricate URLs. Search first, fetch second.

--- a/apps/api/src/ai/system-tools/entity-tools.test.ts
+++ b/apps/api/src/ai/system-tools/entity-tools.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { getTestDb, cleanDb, seedTestUser, closeTestDb, TEST_USER_ID } from "../../test/helpers.js";
+import * as schema from "../../db/schema/index.js";
+import { serializeFields, type EntityField } from "../../db/entity-fields.js";
+import { buildEntityTools } from "./entity-tools.js";
+import type { ToolContext } from "../types.js";
+
+vi.mock("../../ws/index.js", () => ({
+  broadcast: vi.fn(),
+  sendToConversation: vi.fn(),
+  sendToUser: vi.fn(),
+  registerWebSocket: vi.fn(),
+}));
+
+const ENTITY_ID = "ent-entity-tools-test";
+const OTHER_ENTITY_ID = "ent-entity-tools-other";
+
+const fields: EntityField[] = [
+  { id: "f-name", name: "Nome", slug: "nome", type: "text", required: true },
+  { id: "f-price", name: "Preço", slug: "preco", type: "number", required: false },
+  { id: "f-email", name: "Email", slug: "email", type: "email", required: false },
+];
+
+type ToolDef = ReturnType<typeof buildEntityTools>[number];
+function getTool(tools: ToolDef[], name: string): ToolDef {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`Tool ${name} not found`);
+  return t;
+}
+
+function parseResult(result: Awaited<ReturnType<ToolDef["handler"]>>) {
+  const first = result.content[0];
+  if (first.type !== "text") throw new Error("Expected text content");
+  return { text: first.text, isError: result.isError === true };
+}
+
+describe("entity-tools update_record / delete_record", () => {
+  const db = getTestDb();
+  const ctx: ToolContext = { db, userId: TEST_USER_ID, conversationId: "test-conv" };
+  const tools = buildEntityTools(ctx);
+  const updateTool = getTool(tools, "update_record");
+  const deleteTool = getTool(tools, "delete_record");
+
+  beforeAll(async () => {
+    await cleanDb();
+    await seedTestUser(db);
+  });
+
+  beforeEach(async () => {
+    await db.delete(schema.entityRecords);
+    await db.delete(schema.entities);
+
+    await db.insert(schema.entities).values([
+      {
+        id: ENTITY_ID,
+        name: "Clientes",
+        slug: "clientes",
+        fields: serializeFields(fields),
+        createdBy: TEST_USER_ID,
+      },
+      {
+        id: OTHER_ENTITY_ID,
+        name: "Produtos",
+        slug: "produtos",
+        fields: serializeFields(fields),
+        createdBy: TEST_USER_ID,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  describe("update_record", () => {
+    it("merges provided fields with existing data", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: ENTITY_ID,
+        data: JSON.stringify({ nome: "Ana", preco: 100, email: "ana@example.com" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      const res = await updateTool.handler(
+        { entity_name: "Clientes", record_id: recordId, data: { preco: 150 } },
+        {},
+      );
+
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(false);
+      expect(JSON.parse(text)).toMatchObject({ success: true, id: recordId, fields_updated: "preco" });
+
+      const [row] = await db.select().from(schema.entityRecords).where(eq(schema.entityRecords.id, recordId));
+      expect(JSON.parse(row.data)).toEqual({ nome: "Ana", preco: 150, email: "ana@example.com" });
+    });
+
+    it("maps field name to slug when keys use display names", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: ENTITY_ID,
+        data: JSON.stringify({ nome: "Ana" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      await updateTool.handler(
+        { entity_name: "Clientes", record_id: recordId, data: { "Preço": 200, Email: "a@b.com" } },
+        {},
+      );
+
+      const [row] = await db.select().from(schema.entityRecords).where(eq(schema.entityRecords.id, recordId));
+      expect(JSON.parse(row.data)).toEqual({ nome: "Ana", preco: 200, email: "a@b.com" });
+    });
+
+    it("returns error when entity does not exist", async () => {
+      const res = await updateTool.handler(
+        { entity_name: "NonExistent", record_id: "anything", data: { nome: "X" } },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(true);
+      expect(text).toMatch(/Entity "NonExistent" not found/);
+    });
+
+    it("returns error when record does not exist", async () => {
+      const res = await updateTool.handler(
+        { entity_name: "Clientes", record_id: "nonexistent-id", data: { nome: "X" } },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(true);
+      expect(text).toMatch(/Record "nonexistent-id" not found/);
+    });
+
+    it("returns error when record belongs to a different entity", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: OTHER_ENTITY_ID,
+        data: JSON.stringify({ nome: "Widget" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      const res = await updateTool.handler(
+        { entity_name: "Clientes", record_id: recordId, data: { nome: "Changed" } },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(true);
+      expect(text).toMatch(/does not belong to entity "Clientes"/);
+    });
+  });
+
+  describe("delete_record", () => {
+    it("deletes a record that belongs to the entity", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: ENTITY_ID,
+        data: JSON.stringify({ nome: "Ana" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      const res = await deleteTool.handler(
+        { entity_name: "Clientes", record_id: recordId },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(false);
+      expect(JSON.parse(text)).toMatchObject({ success: true, id: recordId });
+
+      const rows = await db.select().from(schema.entityRecords).where(eq(schema.entityRecords.id, recordId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns error when record belongs to a different entity", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: OTHER_ENTITY_ID,
+        data: JSON.stringify({ nome: "Widget" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      const res = await deleteTool.handler(
+        { entity_name: "Clientes", record_id: recordId },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(true);
+      expect(text).toMatch(/does not belong to entity "Clientes"/);
+
+      const rows = await db.select().from(schema.entityRecords).where(eq(schema.entityRecords.id, recordId));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("returns error when record does not exist", async () => {
+      const res = await deleteTool.handler(
+        { entity_name: "Clientes", record_id: "missing-id" },
+        {},
+      );
+      const { text, isError } = parseResult(res);
+      expect(isError).toBe(true);
+      expect(text).toMatch(/Record "missing-id" not found/);
+    });
+
+    it("accepts entity ID in addition to entity name", async () => {
+      const recordId = crypto.randomUUID();
+      await db.insert(schema.entityRecords).values({
+        id: recordId,
+        entityId: ENTITY_ID,
+        data: JSON.stringify({ nome: "Ana" }),
+        createdBy: TEST_USER_ID,
+      });
+
+      const res = await deleteTool.handler(
+        { entity_name: ENTITY_ID, record_id: recordId },
+        {},
+      );
+      expect(parseResult(res).isError).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/ai/system-tools/entity-tools.ts
+++ b/apps/api/src/ai/system-tools/entity-tools.ts
@@ -1,10 +1,36 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, or } from "drizzle-orm";
 import type { ToolContext } from "../types.js";
 import { entities, entityRecords } from "../../db/schema/index.js";
 import { parseFields, serializeFields, slugify, type EntityField } from "../../db/entity-fields.js";
 import { broadcast } from "../../ws/index.js";
+
+type Entity = typeof entities.$inferSelect;
+
+async function resolveEntity(db: ToolContext["db"], nameOrId: string): Promise<Entity | null> {
+  const [match] = await db
+    .select()
+    .from(entities)
+    .where(or(eq(entities.name, nameOrId), eq(entities.id, nameOrId)))
+    .limit(1);
+  return match ?? null;
+}
+
+function mapDataKeysToFieldSlugs(
+  data: Record<string, unknown>,
+  fields: EntityField[],
+): Record<string, unknown> {
+  const mapped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    const keySlug = slugify(key);
+    const matched = fields.find(
+      (f) => f.name === key || f.slug === key || f.slug === keySlug || f.name.toLowerCase() === key.toLowerCase(),
+    );
+    mapped[matched ? matched.slug : keySlug] = value;
+  }
+  return mapped;
+}
 
 export function buildEntityTools(ctx: ToolContext) {
   return [
@@ -149,6 +175,85 @@ export function buildEntityTools(ctx: ToolContext) {
         const usedFields = Object.keys(mappedData).join(", ");
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ success: true, id, fields_used: usedFields }) }],
+        };
+      },
+    ),
+
+    tool(
+      "update_record",
+      "Update fields of an existing record. Only provided fields change; others are preserved. Keys must match the entity's field names (use list_entities to check).",
+      {
+        entity_name: z.string().describe("Name or ID of the entity the record belongs to"),
+        record_id: z.string().describe("ID of the record to update"),
+        data: z.record(z.unknown()).describe("Partial record data as key-value pairs. Only keys you provide are updated."),
+      },
+      async ({ entity_name, record_id, data }) => {
+        const entity = await resolveEntity(ctx.db, entity_name);
+        if (!entity) {
+          return { content: [{ type: "text" as const, text: `Entity "${entity_name}" not found` }], isError: true };
+        }
+
+        const [record] = await ctx.db
+          .select()
+          .from(entityRecords)
+          .where(eq(entityRecords.id, record_id))
+          .limit(1);
+        if (!record) {
+          return { content: [{ type: "text" as const, text: `Record "${record_id}" not found` }], isError: true };
+        }
+        if (record.entityId !== entity.id) {
+          return { content: [{ type: "text" as const, text: `Record "${record_id}" does not belong to entity "${entity.name}"` }], isError: true };
+        }
+
+        const fields = parseFields(entity.fields);
+        const mappedData = mapDataKeysToFieldSlugs(data, fields);
+        const existingData = JSON.parse(record.data as string) as Record<string, unknown>;
+        const mergedData = { ...existingData, ...mappedData };
+
+        await ctx.db
+          .update(entityRecords)
+          .set({ data: JSON.stringify(mergedData), updatedAt: new Date() })
+          .where(eq(entityRecords.id, record_id));
+
+        broadcast({ type: "record_updated", entityId: entity.id });
+
+        const updatedFields = Object.keys(mappedData).join(", ");
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, id: record_id, fields_updated: updatedFields }) }],
+        };
+      },
+    ),
+
+    tool(
+      "delete_record",
+      "Delete a record permanently. Requires entity_name and record_id for safety.",
+      {
+        entity_name: z.string().describe("Name or ID of the entity the record belongs to"),
+        record_id: z.string().describe("ID of the record to delete"),
+      },
+      async ({ entity_name, record_id }) => {
+        const entity = await resolveEntity(ctx.db, entity_name);
+        if (!entity) {
+          return { content: [{ type: "text" as const, text: `Entity "${entity_name}" not found` }], isError: true };
+        }
+
+        const [record] = await ctx.db
+          .select({ id: entityRecords.id, entityId: entityRecords.entityId })
+          .from(entityRecords)
+          .where(eq(entityRecords.id, record_id))
+          .limit(1);
+        if (!record) {
+          return { content: [{ type: "text" as const, text: `Record "${record_id}" not found` }], isError: true };
+        }
+        if (record.entityId !== entity.id) {
+          return { content: [{ type: "text" as const, text: `Record "${record_id}" does not belong to entity "${entity.name}"` }], isError: true };
+        }
+
+        await ctx.db.delete(entityRecords).where(eq(entityRecords.id, record_id));
+        broadcast({ type: "record_updated", entityId: entity.id });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, id: record_id }) }],
         };
       },
     ),


### PR DESCRIPTION
Closes #68

## Summary

The AI agent could only CREATE records — editing or deleting sent users to the admin panel. \`update_record\` and \`delete_record\` were already in the \`MUTATING_TOOLS\` set but had no implementation. This wires them up.

- **update_record**: partial merge with existing record data, maps display names to field slugs (same heuristic as insert_record), verifies the record belongs to the named entity
- **delete_record**: requires \`entity_name\` + \`record_id\`, refuses to delete records that don't belong to the named entity
- Both are mutating tools and route through the existing confirmation flow (\`canUseTool\` in chat-handler) automatically
- System prompt updated so the agent uses them proactively instead of refusing edits/deletes

## Test plan
- [x] Unit tests for update_record (merge, slug mapping, entity 404, record 404, cross-entity ownership)
- [x] Unit tests for delete_record (happy path, cross-entity ownership, record 404, entity ID as name)
- [x] Full API test suite still green (115/115)
- [ ] Manual smoke: in the chat, ask agent to update a field of an existing record and confirm the change
- [ ] Manual smoke: in the chat, ask agent to delete a record and confirm the confirmation dialog appears