### PR TITLE
feat(agent): schedule_task + prompt hardening against harness cron

### DIFF
--- a/apps/api/src/ai/prompts.ts
+++ b/apps/api/src/ai/prompts.ts
@@ -23,6 +23,12 @@ Rules:
 
 For web research, ALWAYS use the web_search tool first to find URLs, then fetch_url to read specific pages. NEVER guess or fabricate URLs. Search first, fetch second.
 For social media research, search via web_search (e.g. "site:instagram.com companyname"). NEVER access profile URLs directly (they block scraping). Individual post URLs from search results DO work.
+
+Scheduling — pick the right tool and never hallucinate an outcome:
+- When the user wants a plain text reminder ("me lembra amanha as 15h de falar com X"), call schedule_reminder. It only fires a notification; it does not run tools.
+- When the user wants actual work done later ("gera um PDF em 5 min", "amanha as 9h envia o relatorio para Y", "daqui 10 min roda a query Z"), call schedule_task. The agent is re-invoked at that time with the stored prompt and can call every tool it has now (generate_pdf, send_email, query_records, etc).
+- Never try to use CronCreate, ScheduleWakeup, or any other meta-tool for scheduling, and never ask the user to keep the session open. These things do not exist in AEX Run. schedule_reminder and schedule_task are the only correct answers.
+- After calling schedule_reminder or schedule_task, only confirm success AFTER the tool returned success=true. If you did not get a successful tool result, say so plainly instead of claiming the task is scheduled.
 `;
 
 export async function buildSystemPrompt(

--- a/apps/api/src/ai/system-tools/reminder-tools.ts
+++ b/apps/api/src/ai/system-tools/reminder-tools.ts
@@ -3,8 +3,9 @@ import { z } from "zod";
 import { and, asc, eq } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import type { ToolContext } from "../types.js";
-import { reminders } from "../../db/schema/index.js";
+import { reminders, tasks } from "../../db/schema/index.js";
 import { cancelReminderJob, enqueueReminder } from "../../queue/reminder-queue.js";
+import { enqueueTask } from "../../queue/task-queue.js";
 
 function parseScheduledFor(value: string): Date | null {
   const d = new Date(value);
@@ -16,7 +17,7 @@ export function buildReminderTools(ctx: ToolContext) {
   return [
     tool(
       "schedule_reminder",
-      "Schedule a persistent reminder that fires at a specific time. The reminder survives session close and server restarts. When it fires, it is posted as a system message in the current conversation (or current user's inbox if no conversation is bound). Use this whenever the user asks to be reminded, notified, or followed up with at a future time.",
+      "Schedule a persistent human-facing reminder that fires at a specific time. The reminder is a plain text notification that is posted as a system message into the conversation (or pushed to the user's inbox if unbound). It does NOT execute any work. Use this when the user wants to be nudged, notified, or followed up with. For scheduling actual work (generate a PDF later, send an email later, run a query later), use `schedule_task` instead.",
       {
         message: z.string().min(1).describe("The reminder text, as it will appear to the user when it fires."),
         scheduled_for: z.string().describe("ISO 8601 datetime for when the reminder should fire (e.g. '2026-04-14T15:00:00-03:00'). Must be in the future."),
@@ -119,6 +120,58 @@ export function buildReminderTools(ctx: ToolContext) {
           .where(eq(reminders.id, reminder_id));
 
         return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, cancelled: reminder_id }) }] };
+      },
+    ),
+
+    tool(
+      "schedule_task",
+      "Schedule the agent to actually run a prompt at a future time. When the scheduled time arrives, the agent is re-invoked in the bound conversation with the stored prompt and full access to its tools (generate_pdf, send_email, query_records, insert_record, update_record, etc). Use this whenever the user asks to produce a document later, send an email later, run a query later, or do any work at a future time. Do NOT use `schedule_reminder` for these cases, and NEVER attempt to use harness tools like `CronCreate`, `ScheduleWakeup`, or shell cron.",
+      {
+        title: z.string().min(1).describe("Short human-readable title for the scheduled task (shown in the Tasks module)."),
+        prompt: z.string().min(1).describe("The exact prompt the agent will be given when the task fires. Write it self-contained, as if the user were asking now, because there is no chat history carried across."),
+        scheduled_for: z.string().describe("ISO 8601 datetime for when the task should run (e.g. '2026-04-14T15:00:00-03:00'). Must be in the future."),
+      },
+      async ({ title, prompt, scheduled_for }) => {
+        const when = new Date(scheduled_for);
+        if (Number.isNaN(when.getTime())) {
+          return { content: [{ type: "text" as const, text: `Invalid scheduled_for: "${scheduled_for}"` }], isError: true };
+        }
+        if (when.getTime() <= Date.now()) {
+          return { content: [{ type: "text" as const, text: "scheduled_for must be in the future" }], isError: true };
+        }
+        if (!ctx.conversationId) {
+          return { content: [{ type: "text" as const, text: "schedule_task requires an active conversation so the result has somewhere to land" }], isError: true };
+        }
+
+        const id = randomUUID();
+        await ctx.db.insert(tasks).values({
+          id,
+          title,
+          description: null,
+          status: "pending",
+          progress: 0,
+          conversationId: ctx.conversationId,
+          createdBy: ctx.userId,
+          input: prompt,
+          scheduledAt: when,
+          type: "inference",
+        });
+
+        const delayMs = Math.max(0, when.getTime() - Date.now());
+        await enqueueTask(id, delayMs);
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              success: true,
+              task_id: id,
+              title,
+              scheduled_for: when.toISOString(),
+              fires_in_seconds: Math.round(delayMs / 1000),
+            }),
+          }],
+        };
       },
     ),
   ];

--- a/apps/api/src/ai/tool-registry.ts
+++ b/apps/api/src/ai/tool-registry.ts
@@ -42,6 +42,7 @@ export const MUTATING_TOOLS = new Set([
   "mcp__aex__delete_knowledge",
   "mcp__aex__schedule_reminder",
   "mcp__aex__cancel_reminder",
+  "mcp__aex__schedule_task",
 ]);
 
 export function isReadOnlyTool(toolName: string): boolean {

--- a/apps/api/src/queue/task-runner.ts
+++ b/apps/api/src/queue/task-runner.ts
@@ -1,3 +1,8 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { db as defaultDb } from "../db/index.js";
+import { resolveAgentForConversation } from "../ai/agent-resolver.js";
+import { buildMcpServer } from "../ai/mcp-server-factory.js";
+import type { ToolContext } from "../ai/types.js";
 import type { Database } from "../db/index.js";
 
 class TaskCancelledException extends Error {
@@ -11,19 +16,73 @@ interface TaskInput {
   id: string;
   type: string;
   title: string;
-  description: string | null;
   input: string | null;
   conversationId: string | null;
+  createdBy: string;
   agentId: string | null;
   toolName: string | null;
   structuredInput: string | null;
+  outputSchema?: string | null;
+  createdAt?: Date | null;
 }
 
-export async function runTask(
-  _task: TaskInput,
-  _db: Database,
-): Promise<string> {
-  throw new Error("AI layer not available. Task execution requires AI to be configured.");
+async function runInferenceTask(task: TaskInput, db: Database): Promise<string> {
+  if (!task.input || !task.input.trim()) {
+    throw new Error("Inference task requires a non-empty input prompt");
+  }
+  if (!task.conversationId) {
+    throw new Error("Inference task requires a conversation_id so the result has somewhere to land");
+  }
+
+  const agentConfig = await resolveAgentForConversation(task.conversationId, task.createdBy);
+  const toolContext: ToolContext = { db, userId: task.createdBy, conversationId: task.conversationId };
+  const mcpServer = buildMcpServer({ agentConfig, toolContext });
+
+  const options: Record<string, unknown> = {
+    systemPrompt: agentConfig.systemPrompt,
+    mcpServers: { aex: mcpServer },
+    allowedTools: [
+      "mcp__aex__*",
+      "WebSearch", "WebFetch", "ToolSearch",
+      "Bash", "Read", "Write", "Edit", "Glob", "Grep",
+      "Agent", "AskUserQuestion", "TodoWrite",
+    ],
+    // Scheduled tasks run without an interactive user to confirm mutations.
+    // The user already authorised the work when they scheduled it.
+    canUseTool: async () => ({ behavior: "allow" as const }),
+    maxTurns: 15,
+    includePartialMessages: false,
+    cwd: process.cwd(),
+    thinking: { type: "adaptive" },
+    model: agentConfig.modelId || "claude-sonnet-4-6",
+  };
+
+  let finalText = "";
+  for await (const message of query({ prompt: task.input, options: options as any })) {
+    if (message.type === "assistant") {
+      const content = (message as any).message?.content ?? (message as any).content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === "text" && typeof block.text === "string") {
+            finalText += block.text;
+          }
+        }
+      }
+    }
+  }
+
+  return finalText.trim() || "(scheduled task finished with no text output)";
+}
+
+export async function runTask(task: TaskInput, db: Database = defaultDb): Promise<string> {
+  if (task.type === "structured") {
+    // Structured mode is declared on the schema (toolName + structuredInput)
+    // but deterministic scheduled execution of a single tool has not been
+    // implemented here yet. Callers who need a fixed tool invocation today
+    // should wrap it in an inference prompt until this is filled in.
+    throw new Error("structured task execution is not implemented yet; use type=\"inference\" with a prompt instead");
+  }
+  return runInferenceTask(task, db);
 }
 
 export { TaskCancelledException };


### PR DESCRIPTION
## Summary

Follow-up to #81 driven by a reproducible failure on staging. User asked the agent to \"gera um PDF daqui 5 min\". Agent logs showed:

1. \`ToolSearch\` for \`schedule_reminder, query_records, generate_pdf\` (it saw the new tools)
2. \`ToolSearch\` for \`CronCreate\` (a Claude Code harness meta-tool)
3. \`Bash date '+%M %H %d %m'\` to build a cron expression
4. \`CronCreate\` call — outside the \`allowedTools\` allowlist, no-op
5. Agent responded \"Agendado. Daqui a 5 minutos (07:54)...\" with no DB row written

Two reasons it picked the wrong path: \`schedule_reminder\` was (correctly) advertised as a text-notification tool, and nothing existed for scheduled *execution*. The agent improvised with whatever it could find.

## Changes

**`schedule_task` tool.** The `tasks` table already had `scheduled_at`, `type=inference`, and a BullMQ queue that accepts `delayMs`. The tool inserts a pending task with the user's frozen prompt and enqueues it with the right delay. The existing `task-worker` picks it up on time, and `reportToChat` posts the result into the bound conversation.

**`runTask` implementation.** The file used to throw \"AI layer not available\". Replaced with a real implementation that:
- Resolves the conversation's agent config (same path as the live chat)
- Builds the MCP server with all system tools (`generate_pdf`, `send_email`, `query_records`, update/delete record, etc)
- Runs Claude Agent SDK `query()` on the stored prompt
- Returns the concatenated assistant text
- `canUseTool` auto-allows mutating tools — the user approved when they scheduled the task

**Prompt hardening (`prompts.ts`).** Explicit Scheduling section:
- `schedule_reminder` = human-facing notification, no work executed
- `schedule_task` = agent re-invoked at that time with full tools
- Never try `CronCreate`, `ScheduleWakeup`, or any meta-tool
- Never tell the user to keep the session open
- Only confirm success **after** the tool returned `success=true`; otherwise say it plainly

**`schedule_reminder` description** tightened to state it does not execute work, so the agent routes correctly on ambiguous requests.

## Schema
No migration. `tasks` was already suitable.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` — no new type errors in changed files
- [x] `vitest run src/ai/system-tools/file-tools.test.ts src/queue/reminder-queue.test.ts` — 6/6 still pass
- [ ] End-to-end on staging: ask Eric \"gera PDF da lista de produtos daqui 5 min\", verify a row lands in `tasks` with `status=pending` and `scheduled_at=<now+5min>`, verify after 5 min the task runs and the generated PDF and AI summary appear in the conversation.
- [ ] End-to-end: ask Eric \"me lembra daqui 1 min de ligar para X\", verify row lands in `reminders` (not `tasks`), verify the system message fires at T+1.
- [ ] Regression: confirm `update_record`/`delete_record`/`insert_record` from #80 still work.

## Risk
- Scheduled task execution grants the agent autonomous mutating access on the user's behalf at fire time. Mitigation: user explicitly authorised at scheduling; the prompt is stored verbatim so the agent re-evaluates with current data rather than replaying cached state.
- `runTask` inference mode requires a `conversationId`. Workflow executor passed `null` — that path was already broken (the old stub threw). This PR does not regress it further; fixing workflow-initiated tasks is a separate ticket.

Targets `staging`.