### PR TITLE
feat(agent): list_tasks, cancel_task, and PDF download link

### DIFF
--- a/apps/api/src/ai/system-tools/file-tools.ts
+++ b/apps/api/src/ai/system-tools/file-tools.ts
@@ -199,6 +199,8 @@ export function buildFileTools(ctx: ToolContext) {
           ownerId: ctx.userId,
         });
 
+        const downloadPath = `/api/files/${id}/download`;
+
         return {
           content: [{
             type: "text" as const,
@@ -208,6 +210,8 @@ export function buildFileTools(ctx: ToolContext) {
               name: displayName,
               size_bytes: buffer.length,
               mime_type: "application/pdf",
+              download_path: downloadPath,
+              note: "Same-origin download. Surface this path as a markdown link in your reply, e.g. [download](" + downloadPath + "), so the user can save the file from chat. Also mention the file appears in the Files panel.",
             }),
           }],
         };

--- a/apps/api/src/ai/system-tools/reminder-tools.ts
+++ b/apps/api/src/ai/system-tools/reminder-tools.ts
@@ -1,11 +1,11 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { and, asc, eq } from "drizzle-orm";
+import { and, desc, asc, eq, inArray } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import type { ToolContext } from "../types.js";
 import { reminders, tasks } from "../../db/schema/index.js";
 import { cancelReminderJob, enqueueReminder } from "../../queue/reminder-queue.js";
-import { enqueueTask } from "../../queue/task-queue.js";
+import { cancelTaskJob, enqueueTask } from "../../queue/task-queue.js";
 
 function parseScheduledFor(value: string): Date | null {
   const d = new Date(value);
@@ -120,6 +120,70 @@ export function buildReminderTools(ctx: ToolContext) {
           .where(eq(reminders.id, reminder_id));
 
         return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, cancelled: reminder_id }) }] };
+      },
+    ),
+
+    tool(
+      "list_tasks",
+      "List scheduled or in-flight tasks created by the current user. Defaults to pending+running so you can see what is queued or in progress; pass `status` to narrow it down. Each row includes id, title, status, scheduled_for and conversation binding.",
+      {
+        status: z.enum(["pending", "running", "completed", "failed", "cancelled"]).optional().describe("Filter by a single status. If omitted, returns pending + running."),
+        limit: z.number().optional().describe("Max rows to return (default 20)."),
+      },
+      async ({ status, limit }) => {
+        const baseFilter = status
+          ? eq(tasks.status, status)
+          : inArray(tasks.status, ["pending", "running"]);
+
+        const rows = await ctx.db
+          .select()
+          .from(tasks)
+          .where(and(eq(tasks.createdBy, ctx.userId), baseFilter))
+          .orderBy(asc(tasks.scheduledAt), desc(tasks.createdAt))
+          .limit(limit ?? 20);
+
+        const result = rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          status: r.status,
+          type: r.type,
+          scheduled_for: r.scheduledAt?.toISOString() ?? null,
+          conversation_id: r.conversationId,
+          started_at: r.startedAt?.toISOString() ?? null,
+          completed_at: r.completedAt?.toISOString() ?? null,
+        }));
+
+        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+      },
+      { annotations: { readOnlyHint: true } },
+    ),
+
+    tool(
+      "cancel_task",
+      "Cancel a scheduled task that has not started yet. If the task is already running it stays as-is (no kill switch); if it already completed/failed/cancelled this is a no-op. Use this whenever the user changes their mind, you scheduled with the wrong time and need to clean up, or you want to clear duplicates.",
+      {
+        task_id: z.string().describe("ID of the task to cancel (from list_tasks or schedule_task)."),
+      },
+      async ({ task_id }) => {
+        const [row] = await ctx.db
+          .select()
+          .from(tasks)
+          .where(and(eq(tasks.id, task_id), eq(tasks.createdBy, ctx.userId)))
+          .limit(1);
+        if (!row) {
+          return { content: [{ type: "text" as const, text: `Task "${task_id}" not found` }], isError: true };
+        }
+        if (row.status !== "pending") {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, already: row.status, task_id }) }] };
+        }
+
+        await cancelTaskJob(task_id);
+        await ctx.db
+          .update(tasks)
+          .set({ status: "cancelled", completedAt: new Date() })
+          .where(eq(tasks.id, task_id));
+
+        return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, cancelled: task_id }) }] };
       },
     ),
 

--- a/apps/api/src/ai/tool-registry.ts
+++ b/apps/api/src/ai/tool-registry.ts
@@ -23,6 +23,7 @@ export const READ_ONLY_TOOLS = new Set([
   "mcp__aex__web_search",
   "mcp__aex__fetch_url",
   "mcp__aex__list_reminders",
+  "mcp__aex__list_tasks",
 ]);
 
 // Mutating tools require user confirmation
@@ -43,6 +44,7 @@ export const MUTATING_TOOLS = new Set([
   "mcp__aex__schedule_reminder",
   "mcp__aex__cancel_reminder",
   "mcp__aex__schedule_task",
+  "mcp__aex__cancel_task",
 ]);
 
 export function isReadOnlyTool(toolName: string): boolean {

--- a/apps/api/src/queue/index.ts
+++ b/apps/api/src/queue/index.ts
@@ -1,5 +1,5 @@
 export { redisConnection } from "./connection.js";
-export { taskQueue, enqueueTask } from "./task-queue.js";
+export { taskQueue, enqueueTask, cancelTaskJob } from "./task-queue.js";
 export { startTaskWorker } from "./task-worker.js";
 export { flowQueue, enqueueFlowRun } from "./flow-queue.js";
 export { startFlowWorker } from "./flow-worker.js";

--- a/apps/api/src/queue/task-queue.ts
+++ b/apps/api/src/queue/task-queue.ts
@@ -10,3 +10,11 @@ export async function enqueueTask(taskId: string, delayMs?: number) {
     { jobId: taskId, ...(delayMs && delayMs > 0 ? { delay: delayMs } : {}) },
   );
 }
+
+/** Remove a still-pending task job from BullMQ. Returns true when the job was found and removed. */
+export async function cancelTaskJob(taskId: string): Promise<boolean> {
+  const job = await taskQueue.getJob(taskId);
+  if (!job) return false;
+  await job.remove();
+  return true;
+}


### PR DESCRIPTION
## Summary

Follow-up to #82. End-to-end staging proof-run worked, but exposed two rough edges:

- The agent scheduled with the wrong timezone first, then re-scheduled correctly. The wrong row stayed pending until I deleted it manually from Redis + Postgres. The agent had no tool to introspect or clean up.
- `generate_pdf` returned only `file_id`. The user asked \"how do I download the PDF?\" because nothing in the agent's reply pointed to the existing `/api/files/{id}/download` endpoint.

## Changes

- **`list_tasks`** (read-only): user-scoped, defaults to pending+running, optional status filter. Mirrors `list_reminders` so introspection is uniform.
- **`cancel_task`** (mutating): removes the still-pending BullMQ job via new `cancelTaskJob(taskId)` helper, then flips the row to `status=cancelled`. No-op for non-pending. Agent is told in the description to call this on dup/wrong-time situations.
- **`generate_pdf`** response now includes `download_path` = `/api/files/{id}/download` (same-origin behind the web Caddy) and a note steering the agent to surface it as a markdown link in chat. Files panel remains the canonical browse view.
- **`tool-registry`**: `list_tasks` read-only, `cancel_task` mutating.
- **`task-queue.ts`**: new `cancelTaskJob`, exported from `queue/index.ts`.

No migration. Tests and typecheck unchanged from baseline.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` — no new errors in changed files
- [x] Existing 6 vitest tests still pass
- [ ] Staging smoke (post-merge): ask Eric \"agenda PDF dos produtos pra daqui 3 min, mas se eu pedir pra cancelar, cancela\", then 30s later \"cancela esse agendamento\". Verify the row goes pending → cancelled and the BullMQ delayed entry disappears.
- [ ] Staging smoke: ask Eric to \"gera PDF da lista de produtos agora\". Verify the reply contains a markdown `[download](...)` link that successfully downloads when clicked.

Targets `staging`.