### PR TITLE
feat(hardening): multi-tenant isolation, boot reconcile, task budgets

### DIFF
--- a/apps/api/src/ai/prompts.ts
+++ b/apps/api/src/ai/prompts.ts
@@ -2,6 +2,7 @@ import { eq, or, and, ne } from "drizzle-orm";
 import { entities, settings, workflows, knowledge } from "../db/schema/index.js";
 import { parseFields } from "../db/entity-fields.js";
 import type { Database } from "../db/index.js";
+import { isSearxngAvailable } from "./system-tools/search-tools.js";
 
 const BASE_PROMPT = `You are Eric, the AI assistant of AEX Run, an AI-First, self-hosted, single-tenant ERP system.
 
@@ -21,7 +22,7 @@ Rules:
 - When asked to delete or remove a record, call delete_record. The system will ask the user for confirmation before running.
 - Use list_entities to check what exists before creating new ones.
 
-For web research, ALWAYS use the web_search tool first to find URLs, then fetch_url to read specific pages. NEVER guess or fabricate URLs. Search first, fetch second.
+For web research, use the web_search tool first to find URLs, then fetch_url to read specific pages. NEVER guess or fabricate URLs. Search first, fetch second.
 For social media research, search via web_search (e.g. "site:instagram.com companyname"). NEVER access profile URLs directly (they block scraping). Individual post URLs from search results DO work.
 
 Scheduling — pick the right tool and never hallucinate an outcome:
@@ -46,6 +47,18 @@ export async function buildSystemPrompt(
     ? BASE_PROMPT.replace("You are Eric,", `You are ${options.agentName},`)
     : BASE_PROMPT;
   sections.push(basePrompt);
+
+  // Runtime advisory based on live infra state. When SearXNG is down the agent
+  // should be told explicitly so it does not keep trying web_search for
+  // external research questions that can only come from the local CRM.
+  if (!isSearxngAvailable()) {
+    sections.push(
+      "\nInfra advisory: the external web search backend is currently unavailable. " +
+      "web_search will transparently fall back to the local CRM only. Do not promise " +
+      "web-sourced answers (news, prices, public company info) until that is resolved. " +
+      "Offer CRM-based answers when the data is already in our records.",
+    );
+  }
 
   // Agent/skill prompt fragments
   if (options?.agentPromptFragments?.length) {

--- a/apps/api/src/ai/system-tools/search-tools.ts
+++ b/apps/api/src/ai/system-tools/search-tools.ts
@@ -1,11 +1,22 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { ToolContext } from "../types.js";
 import { entities, entityRecords } from "../../db/schema/index.js";
 import { parseFields } from "../../db/entity-fields.js";
 
 const SEARXNG_URL = process.env.SEARXNG_URL || "http://searxng:8080";
+
+// Populated by the startup probe so the system prompt and tool descriptions
+// can reflect reality. Defaults to true so that when the probe hasn't run
+// yet we don't prematurely switch to fallback-only messaging.
+let searxngAvailable = true;
+export function setSearxngAvailable(ok: boolean): void {
+  searxngAvailable = ok;
+}
+export function isSearxngAvailable(): boolean {
+  return searxngAvailable;
+}
 
 interface WebResult {
   title: string;
@@ -64,7 +75,12 @@ async function runCrmFallback(ctx: ToolContext, query: string, maxResults: numbe
 
   if (tokens.length === 0) return [];
 
-  const allEntities = await ctx.db.select().from(entities);
+  // Scope to entities the requesting user owns; otherwise this becomes a
+  // cross-user data enumeration surface for anyone with chat access.
+  const allEntities = await ctx.db
+    .select()
+    .from(entities)
+    .where(eq(entities.createdBy, ctx.userId));
   if (allEntities.length === 0) return [];
 
   const hits: CrmHit[] = [];
@@ -74,7 +90,11 @@ async function runCrmFallback(ctx: ToolContext, query: string, maxResults: numbe
     const rows = await ctx.db
       .select()
       .from(entityRecords)
-      .where(sql`${entityRecords.entityId} = ${entity.id} AND (${sql.join(likeClauses, sql` OR `)})`)
+      .where(and(
+        eq(entityRecords.entityId, entity.id),
+        eq(entityRecords.createdBy, ctx.userId),
+        sql`(${sql.join(likeClauses, sql` OR `)})`,
+      ))
       .limit(maxResults);
 
     const fields = parseFields(entity.fields);
@@ -210,22 +230,24 @@ export function buildSearchTools(ctx: ToolContext) {
 }
 
 /**
- * Startup health probe. Non-fatal; just logs so operators know why the agent
- * will use the CRM fallback path.
+ * Startup health probe. Returns whether SearXNG is reachable so callers can
+ * stash the result and expose it to prompt-building.
  */
-export async function probeSearxngHealth(): Promise<void> {
+export async function probeSearxngHealth(): Promise<boolean> {
   try {
     const res = await fetch(`${SEARXNG_URL}/healthz`, {
       signal: AbortSignal.timeout(5000),
     });
     if (res.ok) {
       console.log(`[search] SearXNG reachable at ${SEARXNG_URL}`);
-    } else {
-      console.warn(`[search] SearXNG at ${SEARXNG_URL} returned ${res.status}; web_search will fall back to CRM`);
+      return true;
     }
+    console.warn(`[search] SearXNG at ${SEARXNG_URL} returned ${res.status}; web_search will fall back to CRM`);
+    return false;
   } catch (err) {
     console.warn(
       `[search] SearXNG at ${SEARXNG_URL} not reachable (${err instanceof Error ? err.message : err}); web_search will fall back to CRM`,
     );
+    return false;
   }
 }

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -9,7 +9,11 @@ import * as schema from "./schema/index.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const client = postgres(env.DATABASE_URL);
+const client = postgres(env.DATABASE_URL, {
+  max: Number(process.env.PG_POOL_MAX ?? 30),
+  idle_timeout: 30,
+  connect_timeout: 10,
+});
 export const db = drizzle(client, { schema });
 export type Database = typeof db;
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,26 +15,57 @@ const { startEmailWorker } = await import("./queue/email-worker.js");
 const { startBlingSyncWorker } = await import("./queue/bling-worker.js");
 const { startFileIndexingWorker } = await import("./queue/file-indexing-worker.js");
 const { startReminderWorker } = await import("./queue/reminder-worker.js");
-const { probeSearxngHealth } = await import("./ai/system-tools/search-tools.js");
+const { probeSearxngHealth, setSearxngAvailable } = await import("./ai/system-tools/search-tools.js");
+const { reconcileOnBoot } = await import("./queue/reconcile.js");
 const { loadActiveTriggers } = await import("./workflows/triggers.js");
 const { db, runMigrations } = await import("./db/index.js");
 
 await runMigrations();
+await reconcileOnBoot();
 
 const app = await buildServer();
 
+const workers: Array<{ close: () => Promise<void> }> = [];
+
 try {
   await app.listen({ port: env.PORT, host: "0.0.0.0" });
-  startTaskWorker();
-  startWorkflowWorker();
-  startFlowWorker();
-  startEmailWorker();
-  startBlingSyncWorker();
-  startFileIndexingWorker();
-  startReminderWorker();
-  probeSearxngHealth().catch(() => { /* already logs internally */ });
+  workers.push(startTaskWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startWorkflowWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startFlowWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startEmailWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startBlingSyncWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startFileIndexingWorker() as unknown as { close: () => Promise<void> });
+  workers.push(startReminderWorker() as unknown as { close: () => Promise<void> });
+  probeSearxngHealth().then((ok) => setSearxngAvailable(ok)).catch(() => setSearxngAvailable(false));
   await loadActiveTriggers(db);
 } catch (err) {
   app.log.error(err);
   process.exit(1);
 }
+
+// Graceful shutdown: Railway sends SIGTERM on redeploy. Give in-flight jobs
+// a few seconds to finish, then exit. boot-reconcile handles anything that
+// still ends up orphaned on the next boot.
+let shuttingDown = false;
+async function shutdown(signal: string) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[shutdown] received ${signal}, closing workers and server`);
+  const deadline = Date.now() + 20_000;
+  try {
+    await Promise.race([
+      Promise.all(workers.map((w) => w.close())),
+      new Promise((resolve) => setTimeout(resolve, Math.max(0, deadline - Date.now()))),
+    ]);
+  } catch (err) {
+    console.error("[shutdown] worker close failed:", err);
+  }
+  try {
+    await app.close();
+  } catch (err) {
+    console.error("[shutdown] server close failed:", err);
+  }
+  process.exit(0);
+}
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/apps/api/src/queue/reconcile.ts
+++ b/apps/api/src/queue/reconcile.ts
@@ -1,0 +1,72 @@
+import { and, eq, isNotNull, lt, sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { reminders, tasks } from "../db/schema/index.js";
+import { enqueueReminder } from "./reminder-queue.js";
+import { enqueueTask } from "./task-queue.js";
+
+/**
+ * Boot-time reconciliation. Two responsibilities:
+ *
+ * 1. Mark orphaned `running` tasks as `failed`. These are tasks whose worker
+ *    container was killed mid-execution (SIGKILL on Railway redeploy, OOM,
+ *    etc). Without this, the row is stuck forever.
+ *
+ * 2. Re-enqueue BullMQ jobs for every `pending`/`scheduled` row whose job
+ *    might have been lost (Redis FLUSHDB, Redis swap, container migration).
+ *    BullMQ's stable jobId prevents duplicates when the job is still there.
+ */
+export async function reconcileOnBoot(): Promise<void> {
+  console.log("[reconcile] start");
+
+  // 1. Orphaned running tasks → failed.
+  const orphans = await db
+    .update(tasks)
+    .set({
+      status: "failed",
+      error: "process restart",
+      completedAt: new Date(),
+    })
+    .where(and(
+      eq(tasks.status, "running"),
+      lt(tasks.startedAt, sql`now() - interval '5 minutes'`),
+    ))
+    .returning({ id: tasks.id });
+  if (orphans.length > 0) {
+    console.log(`[reconcile] marked ${orphans.length} orphaned running task(s) as failed`);
+  }
+
+  // 2a. Pending tasks with a scheduled_at → re-enqueue with delay clamped to 0.
+  const pendingScheduled = await db
+    .select({ id: tasks.id, scheduledAt: tasks.scheduledAt })
+    .from(tasks)
+    .where(and(eq(tasks.status, "pending"), isNotNull(tasks.scheduledAt)));
+  for (const row of pendingScheduled) {
+    const delayMs = Math.max(0, (row.scheduledAt?.getTime() ?? Date.now()) - Date.now());
+    try {
+      await enqueueTask(row.id, delayMs);
+    } catch (err) {
+      console.warn(`[reconcile] failed to re-enqueue task ${row.id}:`, err);
+    }
+  }
+  if (pendingScheduled.length > 0) {
+    console.log(`[reconcile] re-enqueued ${pendingScheduled.length} scheduled pending task(s)`);
+  }
+
+  // 2b. Scheduled reminders → re-enqueue.
+  const scheduledReminders = await db
+    .select({ id: reminders.id, scheduledFor: reminders.scheduledFor })
+    .from(reminders)
+    .where(eq(reminders.status, "scheduled"));
+  for (const row of scheduledReminders) {
+    try {
+      await enqueueReminder(row.id, row.scheduledFor);
+    } catch (err) {
+      console.warn(`[reconcile] failed to re-enqueue reminder ${row.id}:`, err);
+    }
+  }
+  if (scheduledReminders.length > 0) {
+    console.log(`[reconcile] re-enqueued ${scheduledReminders.length} scheduled reminder(s)`);
+  }
+
+  console.log("[reconcile] done");
+}

--- a/apps/api/src/queue/reminder-queue.test.ts
+++ b/apps/api/src/queue/reminder-queue.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const addMock = vi.fn(async (_name: string, _data: unknown, opts: { jobId?: string }) => ({ id: opts?.jobId ?? "job" }));
+const addMock = vi.fn(async (_name: string, _data: unknown, opts: { jobId?: string; delay?: number }) => ({ id: opts?.jobId ?? "job" }));
 const getJobMock = vi.fn();
 
 vi.mock("./connection.js", () => ({ redisConnection: {} }));

--- a/apps/api/src/queue/reminder-worker.ts
+++ b/apps/api/src/queue/reminder-worker.ts
@@ -23,12 +23,11 @@ export function startReminderWorker() {
         return;
       }
 
+      // Persist the user-visible side-effects FIRST so a crash between steps
+      // doesn't leave the reminder in `fired` state without the user ever
+      // seeing a message. BullMQ will retry the job and the early-skip above
+      // only triggers after status is flipped at the very end.
       const firedAt = new Date();
-      await db
-        .update(reminders)
-        .set({ status: "fired", firedAt, updatedAt: firedAt })
-        .where(eq(reminders.id, reminderId));
-
       const content = `Reminder: ${reminder.message}`;
 
       if (reminder.conversationId) {
@@ -67,6 +66,11 @@ export function startReminderWorker() {
           firedAt: firedAt.toISOString(),
         });
       }
+
+      await db
+        .update(reminders)
+        .set({ status: "fired", firedAt, updatedAt: firedAt })
+        .where(eq(reminders.id, reminderId));
 
       console.log(`[reminders] fired ${reminderId} for user ${reminder.userId}`);
     },

--- a/apps/api/src/queue/task-runner.ts
+++ b/apps/api/src/queue/task-runner.ts
@@ -2,8 +2,18 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import { db as defaultDb } from "../db/index.js";
 import { resolveAgentForConversation } from "../ai/agent-resolver.js";
 import { buildMcpServer } from "../ai/mcp-server-factory.js";
+import { isReadOnlyTool } from "../ai/tool-registry.js";
 import type { ToolContext } from "../ai/types.js";
 import type { Database } from "../db/index.js";
+
+// Per-execution safety budgets for unattended scheduled tasks. Read-only tools
+// are unlimited; mutating tools are counted, with tighter sub-caps on the
+// operations that are either irreversible (delete_record) or observable to
+// third parties (send_email). If an agent tries to exceed a cap it gets a
+// "denied" tool result and can decide how to proceed in the remaining turns.
+const DEFAULT_MUTATION_BUDGET = Number(process.env.TASK_MUTATION_BUDGET ?? 5);
+const DEFAULT_DELETE_BUDGET = Number(process.env.TASK_DELETE_BUDGET ?? 0);
+const DEFAULT_EMAIL_BUDGET = Number(process.env.TASK_EMAIL_BUDGET ?? 1);
 
 class TaskCancelledException extends Error {
   constructor() {
@@ -38,6 +48,42 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
   const toolContext: ToolContext = { db, userId: task.createdBy, conversationId: task.conversationId };
   const mcpServer = buildMcpServer({ agentConfig, toolContext });
 
+  // Scheduled tasks run without a human-in-the-loop, so we replace the
+  // interactive confirmation flow with hard budgets on mutating operations.
+  let mutationsUsed = 0;
+  let deletesUsed = 0;
+  let emailsUsed = 0;
+  const canUseTool = async (toolName: string) => {
+    if (isReadOnlyTool(toolName)) return { behavior: "allow" as const };
+
+    if (toolName === "mcp__aex__delete_record") {
+      if (deletesUsed >= DEFAULT_DELETE_BUDGET) {
+        return {
+          behavior: "deny" as const,
+          message: `delete_record is disabled in scheduled tasks (budget=${DEFAULT_DELETE_BUDGET}). Ask the user to run this from chat so they can confirm.`,
+        };
+      }
+      deletesUsed += 1;
+    }
+    if (toolName === "mcp__aex__send_email") {
+      if (emailsUsed >= DEFAULT_EMAIL_BUDGET) {
+        return {
+          behavior: "deny" as const,
+          message: `send_email budget exhausted for this task (max ${DEFAULT_EMAIL_BUDGET}).`,
+        };
+      }
+      emailsUsed += 1;
+    }
+    if (mutationsUsed >= DEFAULT_MUTATION_BUDGET) {
+      return {
+        behavior: "deny" as const,
+        message: `Mutation budget exhausted for this scheduled task (${DEFAULT_MUTATION_BUDGET}). Summarise what still needs to happen and stop.`,
+      };
+    }
+    mutationsUsed += 1;
+    return { behavior: "allow" as const };
+  };
+
   const options: Record<string, unknown> = {
     systemPrompt: agentConfig.systemPrompt,
     mcpServers: { aex: mcpServer },
@@ -47,9 +93,7 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
       "Bash", "Read", "Write", "Edit", "Glob", "Grep",
       "Agent", "AskUserQuestion", "TodoWrite",
     ],
-    // Scheduled tasks run without an interactive user to confirm mutations.
-    // The user already authorised the work when they scheduled it.
-    canUseTool: async () => ({ behavior: "allow" as const }),
+    canUseTool,
     maxTurns: 15,
     includePartialMessages: false,
     cwd: process.cwd(),

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { writeFile, mkdir } from "node:fs/promises";
 import { resolve, dirname, extname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { eq } from "drizzle-orm";
+import { and, eq, or, sql } from "drizzle-orm";
 import { auth } from "../auth/index.js";
 import { localStorage, getFileType, getMimeType, formatFileSize, UPLOADS_DIR } from "../files/storage.js";
 
@@ -124,7 +124,7 @@ export function registerUploadRoutes(app: FastifyInstance) {
     });
   });
 
-  // File download (authenticated)
+  // File download (authenticated + owner/share ACL)
   app.get("/api/files/:id/download", async (req, reply) => {
     const headers = new Headers();
     for (const [key, value] of Object.entries(req.headers)) {
@@ -138,15 +138,24 @@ export function registerUploadRoutes(app: FastifyInstance) {
 
     const { id } = req.params as { id: string };
     const { db } = await import("../db/index.js");
-    const { files } = await import("../db/schema/index.js");
+    const { files, fileShares } = await import("../db/schema/index.js");
+    const userId = session.user.id;
 
+    // Authorize: requester must own the file or have a share granting access.
     const [file] = await db
       .select()
       .from(files)
-      .where(eq(files.id, id))
+      .where(and(
+        eq(files.id, id),
+        or(
+          eq(files.ownerId, userId),
+          sql`EXISTS (SELECT 1 FROM ${fileShares} WHERE ${fileShares.fileId} = ${id} AND ${fileShares.userId} = ${userId})`,
+        ),
+      ))
       .limit(1);
 
     if (!file || !file.path) {
+      // 404 rather than 403 so we don't leak existence of files the user can't access.
       return reply.status(404).send({ error: "File not found" });
     }
 

--- a/apps/api/src/scripts/reset-db.ts
+++ b/apps/api/src/scripts/reset-db.ts
@@ -16,6 +16,21 @@ if (!dbUrl) {
   process.exit(1);
 }
 
+// Refuse to run against a DB that looks like production unless the operator
+// confirms via env flag. Destructive operations with an accidentally-exported
+// prod DATABASE_URL have been known to end careers.
+const looksProdLike =
+  process.env.NODE_ENV === "production" ||
+  /railway\.internal|\.proxy\.rlwy\.net/.test(dbUrl);
+if (looksProdLike && process.env.I_REALLY_WANT_TO_RESET !== "yes") {
+  const masked = dbUrl.replace(/:[^@/]+@/, ":***@");
+  console.error(
+    `Refusing to reset a production-like DB: ${masked}\n` +
+    `If you really mean it, re-run with I_REALLY_WANT_TO_RESET=yes in the env.`,
+  );
+  process.exit(2);
+}
+
 console.log("Dropping all tables...");
 
 const postgres = (await import("postgres")).default;


### PR DESCRIPTION
## Summary

Six of the fifteen audit findings (issues #84, #85, #87, #88, #89, #90, partial #91, #95, #96) bundled because they share the same code surface. All are small, defensive fixes that de-risk the next week of real usage by the Buenaça team.

Not in this PR (intentional): #86 (secret rotation — operational, not code), #91 permission re-check at fire time, #92 rate limiting (needs new dep + Redis design), #93 OAuth confused deputy (needs verification read), #94 Sentry integration, #97 session race fix, #98 UI surface.

## What each change does

- **#84 File ACL**: `/api/files/:id/download` now joins on ownership OR a matching `file_shares` row; cross-user download by id no longer works.
- **#85 CRM fallback scope**: `runCrmFallback` filters `entities` and `entity_records` by `createdBy = ctx.userId`. Sendi's `web_search` will no longer leak Andre's customer records.
- **#87 reset-db guard**: refuses prod-like `DATABASE_URL` unless `I_REALLY_WANT_TO_RESET=yes` is set. Masks the password in error output.
- **#88 SIGTERM / graceful shutdown**: workers close first (up to 20s), server second. Exit code 0 on clean shutdown.
- **#89 Boot reconcile**: orphaned `running` tasks → `failed`; every pending scheduled task and scheduled reminder is re-enqueued so `FLUSHDB` or Redis swap no longer silently drops work. BullMQ's stable jobId prevents duplicates when jobs survived.
- **#90 Reminder ordering**: message insert + WS broadcast happen before the `status='fired'` flip. A mid-sequence crash now retries cleanly instead of silently marking fired.
- **#91 partial — task budgets**: scheduled tasks replace blanket auto-allow with per-execution caps (5 mutations, 1 email, 0 deletes by default, all tunable via `TASK_*_BUDGET` env vars). Permission re-check at fire time deferred to a follow-up.
- **#95 PG pool**: `max=30`, explicit `idle_timeout` and `connect_timeout`. Configurable via `PG_POOL_MAX`.
- **#96 SearXNG advisory**: boot probe stores availability; `buildSystemPrompt` appends an "infra advisory" when it's down so the agent doesn't promise web-sourced answers.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` — zero new type errors in the touched files
- [x] `vitest run src/ai/system-tools/file-tools.test.ts src/queue/reminder-queue.test.ts` — 6/6
- [ ] Staging smoke (post-merge, in order):
  - [ ] `curl` `/api/files/<id-of-andre-file>/download` as Sendi → 404 (was 200)
  - [ ] As Sendi in chat: `web_search` for a string that's only in Andre's records → no hit in `source=crm_fallback`
  - [ ] Force `FLUSHDB` on staging Redis, verify boot logs show re-enqueue counts, verify a pending reminder still fires
  - [ ] Schedule a task; mid-execution redeploy via Railway; on next boot, verify the `running` task becomes `failed` and next fresh scheduled task runs
  - [ ] Schedule a task that tries to `delete_record` → tool denied with the budget message

## Follow-ups tracked
- #91 full: permission re-check + task_logs audit
- #92: `/api/chat` rate limit + per-user token budget in Redis
- #93: OAuth confused-deputy verification + session.user.id == stateData.userId
- #94: Sentry / Slack webhook on job failure
- #97: session_id race + stale-session retry double-emit
- #98: UI for reminders/scheduled tasks

Targets `staging`.