### PR TITLE
feat(security): OAuth deputy guard, session CAS, scheduled-task audit log

### DIFF
--- a/apps/api/src/ai/chat-handler.ts
+++ b/apps/api/src/ai/chat-handler.ts
@@ -3,7 +3,7 @@ import type { FastifyReply } from "fastify";
 import { db } from "../db/index.js";
 import { messages } from "../db/schema/index.js";
 import { sendToConversation } from "../ws/index.js";
-import { getSessionId, saveSessionId } from "./session-store.js";
+import { getSessionId, saveSessionId, clearSessionId } from "./session-store.js";
 import { resolveAgentForConversation } from "./agent-resolver.js";
 import { buildMcpServer } from "./mcp-server-factory.js";
 import { isReadOnlyTool } from "./tool-registry.js";
@@ -108,23 +108,6 @@ export async function handleChat(opts: {
       queryOptions.resume = sessionId;
     }
 
-    // Retry helper: if session is stale, clear it and retry without resume
-    const runQuery = async function* () {
-      try {
-        yield* query({ prompt, options: queryOptions as any });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "";
-        if (sessionId && msg.includes("No conversation found with session ID")) {
-          console.log("[chat] Stale session, retrying without resume");
-          await saveSessionId(conversationId, "");
-          delete queryOptions.resume;
-          yield* query({ prompt, options: queryOptions as any });
-        } else {
-          throw err;
-        }
-      }
-    };
-
     // Run the agent
     let finalText = "";
     let textFromStreaming = false;
@@ -134,7 +117,39 @@ export async function handleChat(opts: {
     // Track tools already sent via streaming to avoid duplicates from assistant message
     const sentToolIds = new Set<string>();
 
-    for await (const message of runQuery()) {
+    // If the Claude Code session stored in the DB is stale (container
+    // redeployed and wiped /root/.claude) we need to retry without resume.
+    // Doing that INSIDE the generator used to double-stream: any partial
+    // output from the failed first attempt stayed in finalText and the
+    // retry appended on top. We now reset the client-visible state + local
+    // accumulators before the second attempt.
+    async function* runWithStaleSessionRetry(): AsyncGenerator<unknown> {
+      try {
+        yield* query({ prompt, options: queryOptions as any });
+        return;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "";
+        if (!(sessionId && msg.includes("No conversation found with session ID"))) {
+          throw err;
+        }
+        console.log("[chat] Stale session, retrying without resume");
+        await clearSessionId(conversationId);
+        delete queryOptions.resume;
+
+        finalText = "";
+        textFromStreaming = false;
+        streamingToolInputs.clear();
+        sentToolIds.clear();
+        sendSSE(reply, {
+          type: "text_reset",
+          reason: "stale-session-retry",
+        });
+
+        yield* query({ prompt, options: queryOptions as any });
+      }
+    }
+
+    for await (const message of runWithStaleSessionRetry()) {
       const msgType = message.type;
       const msgSubtype = (message as any).subtype;
       if (msgType !== "stream_event") {
@@ -157,8 +172,11 @@ export async function handleChat(opts: {
       if (message.type === "system" && (message as any).subtype === "init") {
         const newSessionId = (message as any).session_id as string;
         if (!currentSessionId) {
-          currentSessionId = newSessionId;
-          await saveSessionId(conversationId, newSessionId);
+          // expectedPrevious=null means "only set when still empty" — so a
+          // concurrent turn that already claimed this conversation wins and
+          // we skip our overwrite.
+          const ok = await saveSessionId(conversationId, newSessionId, null);
+          if (ok) currentSessionId = newSessionId;
         }
         sendSSE(reply, {
           type: "session_init",
@@ -285,9 +303,11 @@ export async function handleChat(opts: {
       }
     }
 
-    // Persist session ID if it changed
+    // Persist session ID if it changed. The CAS check (expectedPrevious=sessionId)
+    // prevents two concurrent turns from overwriting each other — whoever
+    // wrote first wins, and the loser keeps the winner's session in the DB.
     if (currentSessionId && currentSessionId !== sessionId) {
-      await saveSessionId(conversationId, currentSessionId);
+      await saveSessionId(conversationId, currentSessionId, sessionId);
     }
 
     // Save AI response to DB

--- a/apps/api/src/ai/session-store.ts
+++ b/apps/api/src/ai/session-store.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { conversations } from "../db/schema/index.js";
 
@@ -11,9 +11,47 @@ export async function getSessionId(conversationId: string): Promise<string | nul
   return row?.sessionId ?? null;
 }
 
-export async function saveSessionId(conversationId: string, sessionId: string): Promise<void> {
-  await db
+/**
+ * Save the new Claude Code session id for this conversation, but only when
+ * the stored value still matches what we expected (CAS-style). This avoids
+ * two concurrent turns on the same conversation stomping on each other's
+ * session — the second saver now logs a warning and leaves the winning
+ * session in place. Pass `expectedPrevious=null` to allow overwrite when the
+ * column is empty (first session).
+ */
+export async function saveSessionId(
+  conversationId: string,
+  sessionId: string,
+  expectedPrevious: string | null = null,
+): Promise<boolean> {
+  const updated = await db
     .update(conversations)
     .set({ sessionId, updatedAt: new Date() })
+    .where(and(
+      eq(conversations.id, conversationId),
+      expectedPrevious === null
+        ? or(isNull(conversations.sessionId), eq(conversations.sessionId, ""))
+        : eq(conversations.sessionId, expectedPrevious),
+    ))
+    .returning({ id: conversations.id });
+
+  if (updated.length === 0) {
+    // Another concurrent turn already updated this conversation's session.
+    // The caller's sessionId is now stale; we let whatever is currently in
+    // the DB win so we don't zigzag between two Claude Code sessions.
+    console.warn(
+      `[session-store] saveSessionId raced on conversation ${conversationId} ` +
+      `(expectedPrevious=${expectedPrevious ?? "<empty>"}); keeping current DB value`,
+    );
+    return false;
+  }
+  return true;
+}
+
+/** Force-clear the session (e.g. when the runtime told us the session was stale). */
+export async function clearSessionId(conversationId: string): Promise<void> {
+  await db
+    .update(conversations)
+    .set({ sessionId: sql`NULL`, updatedAt: new Date() })
     .where(eq(conversations.id, conversationId));
 }

--- a/apps/api/src/ai/types.ts
+++ b/apps/api/src/ai/types.ts
@@ -8,6 +8,7 @@ export type SSEEvent =
   | { type: "tool_start"; toolUseId: string; toolName: string; input: Record<string, unknown> }
   | { type: "tool_result"; toolUseId: string; result: unknown; isError: boolean }
   | { type: "tool_confirmation_required"; toolUseId: string; toolName: string; input: Record<string, unknown>; description: string }
+  | { type: "text_reset"; reason: string }
   | { type: "result"; sessionId: string; totalCostUsd?: number; numTurns?: number }
   | { type: "error"; message: string };
 

--- a/apps/api/src/queue/task-runner.ts
+++ b/apps/api/src/queue/task-runner.ts
@@ -1,8 +1,10 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
+import { randomUUID } from "node:crypto";
 import { db as defaultDb } from "../db/index.js";
 import { resolveAgentForConversation } from "../ai/agent-resolver.js";
 import { buildMcpServer } from "../ai/mcp-server-factory.js";
 import { isReadOnlyTool } from "../ai/tool-registry.js";
+import { taskLogs } from "../db/schema/index.js";
 import type { ToolContext } from "../ai/types.js";
 import type { Database } from "../db/index.js";
 
@@ -49,15 +51,38 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
   const mcpServer = buildMcpServer({ agentConfig, toolContext });
 
   // Scheduled tasks run without a human-in-the-loop, so we replace the
-  // interactive confirmation flow with hard budgets on mutating operations.
+  // interactive confirmation flow with hard budgets on mutating operations
+  // and an append to task_logs for every call. The audit trail lets an admin
+  // review exactly what the task did after the fact.
   let mutationsUsed = 0;
   let deletesUsed = 0;
   let emailsUsed = 0;
-  const canUseTool = async (toolName: string) => {
+
+  async function logStep(
+    level: "info" | "warn" | "error" | "step",
+    message: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await db.insert(taskLogs).values({
+        id: randomUUID(),
+        taskId: task.id,
+        level,
+        message,
+        metadata: metadata ? JSON.stringify(metadata) : null,
+      });
+    } catch (err) {
+      // Logging must never break task execution.
+      console.error("[task-runner] failed to write task_log:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  const canUseTool = async (toolName: string, input: unknown) => {
     if (isReadOnlyTool(toolName)) return { behavior: "allow" as const };
 
     if (toolName === "mcp__aex__delete_record") {
       if (deletesUsed >= DEFAULT_DELETE_BUDGET) {
+        await logStep("warn", `denied ${toolName}: delete budget exhausted`, { input });
         return {
           behavior: "deny" as const,
           message: `delete_record is disabled in scheduled tasks (budget=${DEFAULT_DELETE_BUDGET}). Ask the user to run this from chat so they can confirm.`,
@@ -67,6 +92,7 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
     }
     if (toolName === "mcp__aex__send_email") {
       if (emailsUsed >= DEFAULT_EMAIL_BUDGET) {
+        await logStep("warn", `denied ${toolName}: email budget exhausted`, { input });
         return {
           behavior: "deny" as const,
           message: `send_email budget exhausted for this task (max ${DEFAULT_EMAIL_BUDGET}).`,
@@ -75,14 +101,18 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
       emailsUsed += 1;
     }
     if (mutationsUsed >= DEFAULT_MUTATION_BUDGET) {
+      await logStep("warn", `denied ${toolName}: mutation budget exhausted`, { input });
       return {
         behavior: "deny" as const,
         message: `Mutation budget exhausted for this scheduled task (${DEFAULT_MUTATION_BUDGET}). Summarise what still needs to happen and stop.`,
       };
     }
     mutationsUsed += 1;
+    await logStep("step", `allowed ${toolName}`, { input });
     return { behavior: "allow" as const };
   };
+
+  await logStep("info", "scheduled task starting", { conversationId: task.conversationId, prompt: task.input });
 
   const options: Record<string, unknown> = {
     systemPrompt: agentConfig.systemPrompt,
@@ -114,6 +144,10 @@ async function runInferenceTask(task: TaskInput, db: Database): Promise<string> 
       }
     }
   }
+
+  await logStep("info", "scheduled task finished", {
+    mutationsUsed, deletesUsed, emailsUsed, textLength: finalText.length,
+  });
 
   return finalText.trim() || "(scheduled task finished with no text output)";
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -214,6 +214,28 @@ export async function buildServer() {
       return reply.status(400).send({ error: "Missing code or state" });
     }
 
+    // Bind the callback to the currently-logged-in session. Without this, an
+    // attacker can get a `state` signed for user A (the HMAC signer is
+    // BETTER_AUTH_SECRET, shared server-wide), then have user B open the link
+    // in their authenticated browser — the resulting credential would be
+    // created under A. Verifying session.user.id matches state.userId closes
+    // the confused-deputy path.
+    const reqHeaders = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value) reqHeaders.set(key, Array.isArray(value) ? value.join(", ") : value);
+    }
+    const callbackSession = await auth.api.getSession({ headers: reqHeaders });
+    const { verifyOAuthState } = await import("./utils/oauth-state.js");
+    const stateData = verifyOAuthState(state) as { userId?: string } | null;
+    if (!stateData || !stateData.userId) {
+      return reply.status(400).send({ error: "Invalid state" });
+    }
+    if (!callbackSession?.user || callbackSession.user.id !== stateData.userId) {
+      return reply.status(403).send({
+        error: "Session does not match the OAuth flow initiator. Restart the connection from your own account.",
+      });
+    }
+
     try {
       const { handlePluginOAuth2Callback } = await import("./credentials/oauth2-handler.js");
       const { db } = await import("./db/index.js");
@@ -261,6 +283,18 @@ export async function buildServer() {
       };
       if (!stateData) {
         return reply.status(400).send({ error: "Invalid or tampered state parameter" });
+      }
+
+      // Same confused-deputy guard as the plugin OAuth callback above.
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (value) headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+      }
+      const blingSession = await auth.api.getSession({ headers });
+      if (!blingSession?.user || blingSession.user.id !== stateData.userId) {
+        return reply.status(403).send({
+          error: "Session does not match the OAuth flow initiator. Restart the Bling connection from your own account.",
+        });
       }
 
       const { exchangeBlingCode } = await import("./bling/oauth.js");


### PR DESCRIPTION
## Summary

Closes #94 (OAuth confused deputy), closes #96 (session race + double emit), finishes #91 (audit trail).

### #94 OAuth deputy
- `/api/credentials/oauth2/callback` and `/api/auth/bling/callback` now read the session before processing and return 403 if `session.user.id !== stateData.userId`. Without this, state HMAC-signed for user A was usable in user B's authenticated browser, binding the resulting credential to A.

### #96 Session race + double-emit
- `saveSessionId(conversationId, sessionId, expectedPrevious)`: optimistic UPDATE; the call returns `false` and logs a warning when another concurrent turn wrote first. `clearSessionId` for explicit reset.
- Stale-session retry inside `chat-handler` no longer doubles output. On retry: reset `finalText`, `streamingToolInputs`, `sentToolIds`, and emit a new `text_reset` SSE event so the client can clear partial text it had already rendered.

### #91 Audit log
- `task-runner.ts` writes to `task_logs` for: `info` start, `step` per allowed mutating tool with input, `warn` per denied tool with reason, `info` end with budget usage. Logging is best-effort; never throws into the task.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` — no new errors
- [x] `vitest run` of the 2 isolated test files — 6/6
- [ ] Staging smoke:
  - [ ] Issue an OAuth flow as user A, capture `state`, attempt the callback in user B's session — expect 403.
  - [ ] Send 2 chat messages on same conversation simultaneously, watch logs for the CAS warning if they race; verify only one session id wins.
  - [ ] Force a stale session (delete the file under `/root/.claude/projects/<id>/`), send a chat, observe `text_reset` SSE event in network tab + clean response (no doubling).
  - [ ] Schedule a task that calls a few tools, then `SELECT * FROM task_logs WHERE task_id = ?` to see the trail.

## Follow-ups still open
- #97 UI for reminders/scheduled tasks
- #85 Rotate prod/staging secrets (ops)
- #98 SearXNG deploy decision (ops)

Targets `staging`.