### PR TITLE
feat(ui): Reminders panel and Scheduled filter in Tasks page

### DIFF
--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -20,6 +20,7 @@ import { credentialsRouter } from "./routers/credentials.js";
 import { flowsRouter } from "./routers/flows.js";
 import { blingRouter } from "./routers/bling.js";
 import { knowledgeRouter } from "./routers/knowledge.js";
+import { remindersRouter } from "./routers/reminders.js";
 
 export const appRouter = router({
   auth: authRouter,
@@ -43,6 +44,7 @@ export const appRouter = router({
   flows: flowsRouter,
   bling: blingRouter,
   knowledge: knowledgeRouter,
+  reminders: remindersRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/api/src/trpc/routers/reminders.ts
+++ b/apps/api/src/trpc/routers/reminders.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { and, asc, desc, eq } from "drizzle-orm";
+import { router, protectedProcedure } from "../index.js";
+import { reminders } from "../../db/schema/index.js";
+import { cancelReminderJob } from "../../queue/reminder-queue.js";
+
+export const remindersRouter = router({
+  list: protectedProcedure
+    .input(
+      z.object({
+        status: z.enum(["scheduled", "fired", "cancelled"]).optional(),
+        limit: z.number().min(1).max(200).default(100),
+      }).optional().default({}),
+    )
+    .query(async ({ ctx, input }) => {
+      const filter = input.status
+        ? and(eq(reminders.userId, ctx.session.user.id), eq(reminders.status, input.status))
+        : eq(reminders.userId, ctx.session.user.id);
+
+      // Scheduled first (asc by fire time) so the next-to-fire is on top.
+      // Anything else sorted by created date desc (most recent first).
+      const order = input.status === "scheduled"
+        ? asc(reminders.scheduledFor)
+        : desc(reminders.createdAt);
+
+      return ctx.db
+        .select()
+        .from(reminders)
+        .where(filter)
+        .orderBy(order)
+        .limit(input.limit);
+    }),
+
+  cancel: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const [row] = await ctx.db
+        .select()
+        .from(reminders)
+        .where(and(eq(reminders.id, input.id), eq(reminders.userId, ctx.session.user.id)))
+        .limit(1);
+      if (!row) return { error: "Reminder not found" };
+      if (row.status !== "scheduled") return { error: `Already ${row.status}` };
+
+      await cancelReminderJob(input.id);
+      await ctx.db
+        .update(reminders)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(eq(reminders.id, input.id));
+
+      return { success: true };
+    }),
+});

--- a/apps/api/src/trpc/routers/tasks.ts
+++ b/apps/api/src/trpc/routers/tasks.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { eq, desc, asc, sql } from "drizzle-orm";
+import { and, eq, isNotNull, desc, asc, gt, sql } from "drizzle-orm";
 import { router, protectedProcedure } from "../index.js";
 import { tasks, taskLogs } from "../../db/schema/index.js";
-import { enqueueTask } from "../../queue/task-queue.js";
+import { enqueueTask, cancelTaskJob } from "../../queue/task-queue.js";
 import { broadcast } from "../../ws/index.js";
 
 export const tasksRouter = router({
@@ -10,27 +10,27 @@ export const tasksRouter = router({
     .input(
       z.object({
         status: z.enum(["pending", "running", "completed", "failed", "cancelled"]).optional(),
+        scheduledOnly: z.boolean().optional(),
         limit: z.number().min(1).max(100).default(50),
         offset: z.number().min(0).default(0),
       }).optional().default({}),
     )
     .query(async ({ ctx, input }) => {
-      const base = ctx.db
-        .select()
-        .from(tasks);
-
-      if (input.status) {
-        return base
-          .where(eq(tasks.status, input.status))
-          .orderBy(desc(tasks.createdAt))
-          .limit(input.limit)
-          .offset(input.offset);
+      const conditions = [];
+      if (input.status) conditions.push(eq(tasks.status, input.status));
+      if (input.scheduledOnly) {
+        conditions.push(eq(tasks.status, "pending"));
+        conditions.push(isNotNull(tasks.scheduledAt));
+        conditions.push(gt(tasks.scheduledAt, new Date()));
       }
 
-      return base
-        .orderBy(desc(tasks.createdAt))
-        .limit(input.limit)
-        .offset(input.offset);
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+      const order = input.scheduledOnly ? asc(tasks.scheduledAt) : desc(tasks.createdAt);
+
+      const q = ctx.db.select().from(tasks);
+      return where
+        ? q.where(where).orderBy(order).limit(input.limit).offset(input.offset)
+        : q.orderBy(order).limit(input.limit).offset(input.offset);
     }),
 
   getById: protectedProcedure
@@ -74,6 +74,9 @@ export const tasksRouter = router({
         return { error: `Cannot cancel task with status: ${task.status}` };
       }
 
+      // Best-effort: also drop the BullMQ job so a scheduled-but-not-yet-fired
+      // task does not still trigger after we set status=cancelled.
+      try { await cancelTaskJob(input.id); } catch { /* job may already be gone */ }
       await ctx.db
         .update(tasks)
         .set({ status: "cancelled", completedAt: new Date() })

--- a/apps/web/src/components/screens/RemindersPanel/RemindersPanel.tsx
+++ b/apps/web/src/components/screens/RemindersPanel/RemindersPanel.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { Bell, X, History } from "lucide-react";
+import { trpc } from "../../../lib/trpc";
+
+type StatusFilter = "scheduled" | "fired" | "cancelled";
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString();
+}
+
+function relativeFromNow(iso: string): string {
+  const d = new Date(iso).getTime();
+  const now = Date.now();
+  const diffMs = d - now;
+  const past = diffMs < 0;
+  const abs = Math.abs(diffMs);
+  const min = Math.round(abs / 60000);
+  if (min < 1) return past ? "just now" : "in <1m";
+  if (min < 60) return past ? `${min}m ago` : `in ${min}m`;
+  const h = Math.round(min / 60);
+  if (h < 24) return past ? `${h}h ago` : `in ${h}h`;
+  const days = Math.round(h / 24);
+  return past ? `${days}d ago` : `in ${days}d`;
+}
+
+export function RemindersPanel() {
+  const [status, setStatus] = useState<StatusFilter>("scheduled");
+  const utils = trpc.useUtils();
+  const remindersQuery = trpc.reminders.list.useQuery({ status });
+  const cancelMut = trpc.reminders.cancel.useMutation({
+    onSuccess: () => utils.reminders.list.invalidate(),
+  });
+
+  const rows = remindersQuery.data ?? [];
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <div style={{ display: "flex", gap: 6, padding: "10px 16px", borderBottom: "1px solid var(--border)" }}>
+        {(["scheduled", "fired", "cancelled"] as StatusFilter[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => setStatus(s)}
+            style={{
+              padding: "5px 12px",
+              fontSize: 12,
+              border: "1px solid var(--border)",
+              borderRadius: 999,
+              background: status === s ? "var(--accent-light, #fff5f0)" : "transparent",
+              color: status === s ? "var(--accent)" : "var(--text-muted)",
+              fontWeight: status === s ? 600 : 500,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              textTransform: "capitalize",
+              fontFamily: "inherit",
+            }}
+          >
+            {s === "scheduled" ? <Bell size={12} /> : <History size={12} />}
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        {rows.length === 0 ? (
+          <div style={{ padding: 32, color: "var(--text-muted)", fontSize: 13, textAlign: "center" }}>
+            No {status} reminders.
+          </div>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {rows.map((r) => (
+              <li
+                key={r.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "12px 16px",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                <Bell size={16} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 14, color: "var(--text)", marginBottom: 2, wordBreak: "break-word" }}>
+                    {r.message}
+                  </div>
+                  <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                    {formatWhen(r.scheduledFor)}
+                    {" · "}
+                    {relativeFromNow(r.scheduledFor)}
+                    {r.conversationId ? " · in chat" : " · personal"}
+                  </div>
+                </div>
+                {status === "scheduled" && (
+                  <button
+                    onClick={() => cancelMut.mutate({ id: r.id })}
+                    disabled={cancelMut.isPending}
+                    style={{
+                      padding: "4px 10px",
+                      fontSize: 12,
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      background: "transparent",
+                      color: "var(--text-muted)",
+                      cursor: "pointer",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    <X size={12} />
+                    Cancel
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/TasksPage.tsx
+++ b/apps/web/src/pages/TasksPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { Activity, CheckCircle2, XCircle, Clock } from "lucide-react";
+import { Activity, CheckCircle2, XCircle, Clock, Bell } from "lucide-react";
 import { trpc } from "../lib/trpc";
 import { TasksScreen, type FilterItem } from "../components/screens/TasksScreen/TasksScreen";
 import { StatsCard } from "../components/molecules/StatsCard/StatsCard";
 import type { Task } from "../components/organisms/TaskList/TaskList";
 import { TaskDetailPanel } from "./TaskDetailPanel";
+import { RemindersPanel } from "../components/screens/RemindersPanel/RemindersPanel";
 import { useTranslation } from "react-i18next";
 
 function formatRelativeTime(date: string | Date): string {
@@ -35,11 +36,14 @@ export function TasksPage() {
   const { t } = useTranslation();
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState("all");
+  const [view, setView] = useState<"tasks" | "reminders">("tasks");
 
   const tasksQuery = trpc.tasks.list.useQuery(
-    activeFilter !== "all"
-      ? { status: activeFilter as "pending" | "running" | "completed" | "failed" | "cancelled" }
-      : undefined,
+    activeFilter === "scheduled"
+      ? { scheduledOnly: true }
+      : activeFilter !== "all"
+        ? { status: activeFilter as "pending" | "running" | "completed" | "failed" | "cancelled" }
+        : undefined,
   );
   const statsQuery = trpc.tasks.stats.useQuery();
   const cancelMut = trpc.tasks.cancel.useMutation({
@@ -62,6 +66,7 @@ export function TasksPage() {
     { id: "all", label: t('tasks.allTasks'), count: total },
     { id: "running", label: t('status.running'), count: stats.running },
     { id: "pending", label: t('status.pending'), count: stats.pending },
+    { id: "scheduled", label: "Scheduled", count: undefined },
     { id: "completed", label: t('tasks.completedToday'), count: stats.completedToday },
     { id: "failed", label: t('status.failed'), count: stats.failed },
   ];
@@ -130,22 +135,53 @@ export function TasksPage() {
         />
       </div>
 
+      {/* View toggle */}
+      <div style={{ display: "flex", gap: 4, padding: "8px 20px", borderBottom: "1px solid var(--border)", flexShrink: 0 }}>
+        {(["tasks", "reminders"] as const).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            style={{
+              padding: "6px 14px",
+              fontSize: 13,
+              fontWeight: view === v ? 600 : 500,
+              border: "1px solid var(--border)",
+              background: view === v ? "var(--accent-light, #fff5f0)" : "transparent",
+              color: view === v ? "var(--accent)" : "var(--text-muted)",
+              borderRadius: 8,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontFamily: "inherit",
+            }}
+          >
+            {v === "reminders" ? <Bell size={14} /> : <Activity size={14} />}
+            {v === "tasks" ? "Tasks" : "Reminders"}
+          </button>
+        ))}
+      </div>
+
       {/* Main content */}
       <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
         <div style={{ flex: 1, overflow: "hidden" }}>
-          <TasksScreen
-            tasks={tasks}
-            filters={filters}
-            activeFilter={activeFilter}
-            onFilterChange={setActiveFilter}
-            runningCount={stats.running}
-            onCancel={(id) => cancelMut.mutate({ id })}
-            onRetry={(id) => retryMut.mutate({ id })}
-            onViewLogs={(id) => setSelectedTaskId(id)}
-          />
+          {view === "tasks" ? (
+            <TasksScreen
+              tasks={tasks}
+              filters={filters}
+              activeFilter={activeFilter}
+              onFilterChange={setActiveFilter}
+              runningCount={stats.running}
+              onCancel={(id) => cancelMut.mutate({ id })}
+              onRetry={(id) => retryMut.mutate({ id })}
+              onViewLogs={(id) => setSelectedTaskId(id)}
+            />
+          ) : (
+            <RemindersPanel />
+          )}
         </div>
 
-        {selectedTaskId && (
+        {selectedTaskId && view === "tasks" && (
           <TaskDetailPanel
             taskId={selectedTaskId}
             onClose={() => setSelectedTaskId(null)}


### PR DESCRIPTION
Closes #97 (no UI to inspect/cancel reminders and scheduled tasks).

## Summary

- New tRPC router `reminders` with `list` and `cancel`. list is user-scoped and orders scheduled-for ascending so the next-to-fire is on top; cancel drops the BullMQ job and flips the status.
- `tasks.list` gets a `scheduledOnly` option that returns pending tasks with `scheduled_at > now()`, ordered by fire time.
- `tasks.cancel` now also calls `cancelTaskJob` so a UI cancel really prevents the task from firing (previously only flipped DB status).
- `TasksPage` now has a Tasks / Reminders toggle at the top. The "Tasks" side adds a new "Scheduled" filter. The "Reminders" side mounts a new `RemindersPanel` with scheduled / fired / cancelled tabs and a Cancel button on scheduled rows.

No schema migration. Both APIs query existing tables.

## Test plan
- [x] api + web typecheck — clean
- [ ] Staging smoke: Tasks → Scheduled filter shows the next scheduled task with "Scheduled in Xm" description; cancel button removes it from the list and the row status flips to cancelled. Reminders tab shows scheduled reminders; cancel works.